### PR TITLE
fix: prevent infinite comment loop with cooldown + optional bot prefix"

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,95 +1,64 @@
-# ========================
-# Remediarr Web Server
-# ========================
+# ====== Web server ======
 APP_HOST=0.0.0.0
 APP_PORT=8189
 
-# Optional webhook verification
+# Optional shared secret from Jellyseerr (sent as X-Jellyseerr-Signature or custom header)
+# If unset, signature verification is skipped.
 WEBHOOK_SHARED_SECRET=
+
+# If Jellyseerr lets you set a custom header + value, set them (optional):
 WEBHOOK_HEADER_NAME=X-Jellyseerr-Token
 WEBHOOK_HEADER_VALUE=
 
-# ========================
-# Sonarr / Radarr
-# ========================
+# ====== Sonarr settings ======
 SONARR_URL=http://sonarr:8989
 SONARR_API_KEY=
 
+# ====== Radarr settings ======
 RADARR_URL=http://radarr:7878
 RADARR_API_KEY=
 
-# ========================
-# Jellyseerr
-# ========================
-JELLYSEERR_URL=http://jellyseerr:5055
-JELLYSEERR_API_KEY=
-JELLYSEERR_COACH_REPORTERS=true
-JELLYSEERR_COMMENT_ON_ACTION=true
-JELLYSEERR_CLOSE_ISSUES=false
-
-# ========================
-# TMDB (movies digital release check)
-# ========================
+# ====== TMDB for digital release checks (movies) ======
 TMDB_API_KEY=
-SEARCH_ONLY_IF_DIGITAL_RELEASE=true
+PREFER_RADARR_RELEASE_DATE=false
 
-# ========================
-# Keywords (comma-separated, case-insensitive)
-# ========================
+# ---------- TV keyword sets (comma-separated; case-insensitive) ----------
 TV_AUDIO_KEYWORDS=no audio,no sound,missing audio,audio issue
 TV_VIDEO_KEYWORDS=no video,video glitch,black screen,stutter,pixelation
 TV_SUBTITLE_KEYWORDS=missing subs,no subtitles,bad subtitles,wrong subs,subs out of sync
 TV_OTHER_KEYWORDS=buffering,playback error,corrupt file
 
+# ---------- Movie keyword sets ----------
 MOVIE_AUDIO_KEYWORDS=no audio,no sound,audio issue
 MOVIE_VIDEO_KEYWORDS=no video,video missing,bad video,broken video,black screen
 MOVIE_SUBTITLE_KEYWORDS=missing subs,no subtitles,bad subtitles,wrong subs,subs out of sync
 MOVIE_OTHER_KEYWORDS=buffering,playback error,corrupt file
 MOVIE_WRONG_KEYWORDS=not the right movie,wrong movie,incorrect movie
 
-# ====== Notifications (optional) ======
-# Comma or whitespace separated Apprise URLs
-# Examples:
-#  - discord://webhook_id/webhook_token
-#  - tgram://BOT_TOKEN/CHAT_ID
-#  - pushover://USER_KEY@TOKEN
-#  - matrixs://user:pass@homeserver/#room
-#  - mailto://user:pass@smtp.example.com?to=you@example.com
-APPRISE_URLS=
+# ---------- Behavior toggles ----------
+JELLYSEERR_COACH_REPORTERS=true
+JELLYSEERR_COMMENT_ON_ACTION=true
+JELLYSEERR_CLOSE_ISSUES=false
+SEARCH_ONLY_IF_DIGITAL_RELEASE=true
+ENABLE_BLOCKLIST=true
 
-# Optional prefix for Apprise notification titles
-APPRISE_TITLE_PREFIX=[Remediarr]
+# ====== Jellyseerr settings ======
+JELLYSEERR_URL=http://jellyseerr:5055
+JELLYSEERR_API_KEY=
 
+# (NEW) Optional prefix added to all Remediarr bot comments
+# Default: [Remediarr]
+JELLYSEERR_BOT_COMMENT_PREFIX=[Remediarr]
 
-# ========================
-# Gotify Notifications (still supported)
-# ========================
+# (NEW) Cooldown in seconds to avoid endless loops when Remediarr comments trigger its own webhook
+# Default: 90
+REMEDIARR_ISSUE_COOLDOWN_SEC=90
+
+# ====== Notifications ======
+# Gotify
 GOTIFY_URL=
 GOTIFY_TOKEN=
 GOTIFY_PRIORITY=5
 
-# ========================
-# Remediarr Custom Messages
-# ========================
-# Coaching (uses {keywords})
-MSG_COACH_TV_AUDIO=[Remediarr] Tip: include one of these keywords to auto-fix TV audio (delete episode file + re-download): {keywords}.
-MSG_COACH_TV_VIDEO=[Remediarr] Tip: include one of these keywords to auto-fix TV video: {keywords}.
-MSG_COACH_TV_SUBTITLE=[Remediarr] Tip: include one of these keywords to auto-fix TV subtitles: {keywords}.
-MSG_COACH_TV_OTHER=[Remediarr] Tip: include one of these keywords to trigger automation for TV other: {keywords}.
-MSG_COACH_MOV_AUDIO=[Remediarr] Tip: include one of these keywords to auto-handle movie audio: {keywords}.
-MSG_COACH_MOV_VIDEO=[Remediarr] Tip: include one of these keywords to auto-handle movie video: {keywords}.
-MSG_COACH_MOV_SUBTITLE=[Remediarr] Tip: include one of these keywords to auto-handle movie subtitles: {keywords}.
-MSG_COACH_MOV_OTHER=[Remediarr] Tip: include one of these keywords to auto-handle movie other: {keywords}.
-
-# TV action messages (uses {title} {season} {episode})
-MSG_TV_EP_REPLACED=[Remediarr] {title} S{season:02d}E{episode:02d} – deleted file and re-download started.
-MSG_TV_EP_SEARCH_ONLY=[Remediarr] {title} S{season:02d}E{episode:02d} – re-download started.
-MSG_TV_OTHER_SEARCH_ONLY=[Remediarr] {title} S{season:02d}E{episode:02d} – search triggered (no delete).
-
-# Movie action messages (uses {title} {deleted})
-MSG_MOV_GENERIC_HANDLED=[Remediarr] {title}: blocklisted last grab, deleted {deleted} file(s), search started.
-MSG_MOV_WRONG_HANDLED=[Remediarr] Wrong movie: {title}. Blocklisted last grab, deleted {deleted} file(s), search started.
-MSG_MOV_WRONG_NO_RELEASE=[Remediarr] Wrong movie: {title}. Blocklisted last grab, deleted {deleted} file(s). Not searching (not digitally released).
-
-# Autoclose failure
-MSG_AUTOCLOSE_FAIL=[Remediarr] Action completed but I couldn’t auto-close this issue. Please close it once you verify it’s fixed.
+# Apprise (Discord, Telegram, Slack, etc.)
+APPRISE_URL=


### PR DESCRIPTION
Prevent loop condition when the webhook is notified on issues comments so it doesn't loop and comment on its own comments on issues.