### PR TITLE
feat: add configurable retry logic for startup health checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -186,6 +186,20 @@ MSG_AUTOCLOSE_FAIL=Action completed but I couldn't auto-close this issue. Please
 # HTTP_MAX_RETRIES=3
 # HTTP_RETRY_BACKOFF=2.0
 
+# ====== STARTUP HEALTH CHECK SETTINGS ======
+# Health check retry configuration for startup
+# When Remediarr starts, it checks if Sonarr and Radarr are accessible
+# These settings control retry behavior if services aren't ready yet
+
+# Number of retry attempts for startup health checks
+# Useful when services start in different order (Remediarr before Sonarr/Radarr)
+# Set to 0 to disable retries (fail immediately if service unavailable)
+STARTUP_HEALTH_CHECK_RETRIES=3
+
+# Seconds to wait between health check retry attempts
+# Increase if your services take longer to become ready
+STARTUP_HEALTH_CHECK_DELAY=10
+
 ########################################
 # EXAMPLE CONFIGURATIONS
 ########################################

--- a/app/config.py
+++ b/app/config.py
@@ -100,6 +100,10 @@ class Settings(BaseSettings):
     # ===== Cooldown =====
     REMEDIARR_ISSUE_COOLDOWN_SEC: int = 90
 
+    # ===== Startup Health Check Settings =====
+    STARTUP_HEALTH_CHECK_RETRIES: int = 3
+    STARTUP_HEALTH_CHECK_DELAY: int = 10  # seconds between retries
+
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
 

--- a/app/services/health.py
+++ b/app/services/health.py
@@ -18,19 +18,54 @@ async def _ping_json(url: str, headers: dict) -> Tuple[bool, str]:
         return False, str(e)
 
 
+async def _health_check_with_retry(service_name: str, check_func) -> Tuple[bool, str]:
+    """
+    Perform health check with configurable retries and delay.
+    
+    Args:
+        service_name: Name of the service being checked (for logging)
+        check_func: Async function that returns (bool, str) tuple
+        
+    Returns:
+        Tuple of (success, detail_message)
+    """
+    retries = cfg.STARTUP_HEALTH_CHECK_RETRIES
+    delay = cfg.STARTUP_HEALTH_CHECK_DELAY
+    
+    for attempt in range(1, retries + 1):
+        log.info("Health check %s: attempt %d/%d", service_name, attempt, retries)
+        
+        ok, detail = await check_func()
+        
+        if ok:
+            log.info("Health check %s: SUCCESS on attempt %d", service_name, attempt)
+            return ok, detail
+        
+        log.warning("Health check %s: FAILED attempt %d/%d - %s", 
+                   service_name, attempt, retries, detail)
+        
+        # Don't sleep after the last attempt
+        if attempt < retries:
+            log.info("Health check %s: waiting %ds before retry...", service_name, delay)
+            await asyncio.sleep(delay)
+    
+    log.error("Health check %s: FAILED after %d attempts", service_name, retries)
+    return False, f"Failed after {retries} attempts. Last error: {detail}"
+
+
 async def sonarr_ok() -> Tuple[bool, str]:
-    url = cfg.SONARR_URL.rstrip("/") + "/api/v3/system/status"
-    headers = {"X-Api-Key": cfg.SONARR_API_KEY}
-    ok, detail = await _ping_json(url, headers)
-    if not ok:
-        log.warning("Sonarr health check failed: %s", detail)
-    return ok, detail
+    async def _check():
+        url = cfg.SONARR_URL.rstrip("/") + "/api/v3/system/status"
+        headers = {"X-Api-Key": cfg.SONARR_API_KEY}
+        return await _ping_json(url, headers)
+    
+    return await _health_check_with_retry("Sonarr", _check)
 
 
 async def radarr_ok() -> Tuple[bool, str]:
-    url = cfg.RADARR_URL.rstrip("/") + "/api/v3/system/status"
-    headers = {"X-Api-Key": cfg.RADARR_API_KEY}
-    ok, detail = await _ping_json(url, headers)
-    if not ok:
-        log.warning("Radarr health check failed: %s", detail)
-    return ok, detail
+    async def _check():
+        url = cfg.RADARR_URL.rstrip("/") + "/api/v3/system/status"
+        headers = {"X-Api-Key": cfg.RADARR_API_KEY}
+        return await _ping_json(url, headers)
+    
+    return await _health_check_with_retry("Radarr", _check)


### PR DESCRIPTION
- Add STARTUP_HEALTH_CHECK_RETRIES (default: 3) and STARTUP_HEALTH_CHECK_DELAY (default: 10s) environment variables
- Implement retry functionality in health.py with detailed logging for each attempt
- Allow Remediarr to gracefully wait for Sonarr/Radarr to become available during startup
- Update .env.example with comprehensive documentation for new settings

This prevents startup failures when services start in different order or when dependencies take time to become ready.