### PR TITLE
Fix/improvement for introduction of disable startup notification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -170,6 +170,9 @@ TMDB_API_KEY=
 # ====== NOTIFICATION SETTINGS ======
 # Send notifications when actions are taken (optional)
 
+# Disables healthcheck notification on application startup if set to true
+DISABLE_STARTUP_NOTIFICATION=false
+
 # Gotify Push Notifications
 # Self-hosted notification server: https://gotify.net/
 GOTIFY_URL=

--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ When users don't include recognizable keywords, Remediarr posts helpful suggesti
 
 ## Notifications
 
+By default, a healthcheck notification is sent on every application startup. This behavior can be disabled by adding the following:
+
+```bash
+DISABLE_STARTUP_NOTIFICATION=true
+```
+
 ### Gotify
 ```bash
 GOTIFY_URL=https://gotify.example.com

--- a/app/config.py
+++ b/app/config.py
@@ -97,7 +97,7 @@ class Settings(BaseSettings):
     GOTIFY_URL: Optional[str] = None
     GOTIFY_TOKEN: Optional[str] = None
     GOTIFY_PRIORITY: int = 5
-    DISABLE_STARTUP_NOTIFICATION: str = False
+    DISABLE_STARTUP_NOTIFICATION: bool = False
 
     # ===== Customizable messages =====
     MSG_MOVIE_SUCCESS: Optional[str] = None


### PR DESCRIPTION
I was very tired last night and accidentally assigned type string to DISABLE_STARTUP_NOTIFICATION when it should've been bool. This would lead to application erroring on startup as the default value of False did not match type of string

I also added information to Readme.md and .env.example explaining how to use the new config option