### PR TITLE
feat: add ISSUE_TYPE_AS_BUCKET — drive the action from the issue type

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,15 @@ JELLYSEERR_CLOSE_ISSUES=true
 # false: Take actions silently without commenting
 JELLYSEERR_COMMENT_ON_ACTION=true
 
+# Derive the remediation action from the Jellyseerr/Overseerr issue TYPE
+# (Audio/Video/Subtitle/Other) instead of scanning the comment for keywords.
+# true:  the issue TYPE drives the action and the COMMENT IS IGNORED, so a user
+#        can just pick "Audio" with no comment. Audio/Video/Subtitle => delete +
+#        re-search; Other => search only (no delete). The *_KEYWORDS lists are
+#        unused while this is on.
+# false: (default) match comment keywords as usual.
+ISSUE_TYPE_AS_BUCKET=false
+
 # ====== BAZARR INTEGRATION (OPTIONAL) ======
 # Subtitle management integration with Bazarr
 # Leave empty to disable Bazarr integration (default behavior)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,16 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt pytest
+      - run: python -m pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+# python
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Remediarr is a lightweight webhook service that automatically fixes common media
 - **🎬 Movie Automation**: Handles audio, video, subtitle issues, and wrong movie downloads
 - **📺 TV Show Automation**: Manages episode-specific problems with season/episode detection  
 - **🤖 Smart Keyword Detection**: Recognizes issue types from user comments
+- **🏷️ Type-Driven Mode** *(opt-in)*: Let the Jellyseerr issue **Type** pick the action — no keywords needed (`ISSUE_TYPE_AS_BUCKET`)
 - **💬 User Coaching**: Suggests correct keywords when users don't use recognizable terms
 - **🔄 Loop Prevention**: Avoids processing its own comments and resolved issues
 - **📱 Notifications**: Optional Gotify and Apprise integration
@@ -26,6 +27,8 @@ Remediarr is a lightweight webhook service that automatically fixes common media
 5. **Deletes bad file** and triggers new download in Sonarr
 6. **Comments on issue**: "S02E05: replaced file; new download grabbed"
 7. **Closes the issue** automatically
+
+> **Type-driven mode (opt-in):** set `ISSUE_TYPE_AS_BUCKET=true` and step 3 uses the issue **Type** (Audio/Video/Subtitle/Other) instead of comment keywords — the comment is ignored. Audio/Video/Subtitle delete + re-search; Other searches only.
 
 ## Quick Start
 
@@ -137,6 +140,7 @@ Remediarr is configured entirely through environment variables. See the [complet
 |----------|-------------|---------|
 | `BAZARR_URL` | Bazarr base URL (for subtitle management) | `http://bazarr:6767` |
 | `BAZARR_API_KEY` | Bazarr API key | `jkl012...` |
+| `ISSUE_TYPE_AS_BUCKET` | When `true`, the issue **Type** (Audio/Video/Subtitle/Other) drives the action and the **comment is ignored** — a user can just pick a type with no comment. Audio/Video/Subtitle delete + re-search; Other searches only. The `*_KEYWORDS` lists are unused while on. Default `false`. | `false` |
 
 ### Keyword Customization
 

--- a/app/config.py
+++ b/app/config.py
@@ -79,6 +79,9 @@ class Settings(BaseSettings):
     # ===== Behavior toggles =====
     JELLYSEERR_CLOSE_ISSUES: bool = True
     JELLYSEERR_COMMENT_ON_ACTION: bool = True
+    # When true, the Seerr issue TYPE (audio/video/subtitle/other) drives the
+    # remediation action and the comment is ignored. OFF by default.
+    ISSUE_TYPE_AS_BUCKET: bool = False
 
     # ===== Keyword buckets (comma-separated) =====
     TV_AUDIO_KEYWORDS: str = "no audio,no sound,missing audio,audio issue,wrong language,not in english"

--- a/app/webhooks/handlers.py
+++ b/app/webhooks/handlers.py
@@ -66,7 +66,32 @@ def _bucket_for(text: str, media_type: Optional[str]) -> Optional[str]:
     for keyword in (MOV_OTHER | TV_OTHER):
         if keyword in t:
             return "other"
-    
+
+    return None
+
+# Seerr issue TYPE -> bucket, for ISSUE_TYPE_AS_BUCKET mode (no comment needed).
+# Ints match the upstream Overseerr/Jellyseerr IssueType enum
+# (server/constants/issue.ts: VIDEO=1, AUDIO=2, SUBTITLES=3, OTHER=4). The webhook
+# body's string `issue_type` is preferred; this int `issueType` is the fallback.
+_ISSUE_TYPE_INT_TO_BUCKET = {1: "video", 2: "audio", 3: "subtitle", 4: "other"}
+_VALID_TYPE_BUCKETS = {"audio", "video", "subtitle", "other"}
+
+def _bucket_from_issue_type(issue: Dict[str, Any]) -> Optional[str]:
+    """Derive the bucket straight from the Seerr issue TYPE (comment ignored).
+
+    Prefers the webhook-body string ``issue_type`` ("audio"/"video"/...);
+    falls back to the API integer ``issueType`` (1=video, 2=audio, 3=subtitle,
+    4=other). Returns None if neither yields a valid bucket. "wrong" is not
+    reachable here (Seerr has no "wrong" issue type) — that stays keyword-only.
+    """
+    if not issue:
+        return None
+    raw = str(issue.get("issue_type") or "").strip().lower()
+    if raw in _VALID_TYPE_BUCKETS:
+        return raw
+    iv = _to_int_or_none(issue.get("issueType"))
+    if iv in _ISSUE_TYPE_INT_TO_BUCKET:
+        return _ISSUE_TYPE_INT_TO_BUCKET[iv]
     return None
 
 def _to_int_or_none(val) -> Optional[int]:
@@ -468,12 +493,22 @@ async def handle_jellyseerr(payload: Dict[str, Any]) -> Dict[str, Any]:
         log.info("Current comment is ours; skipping.")
         return {"ok": True, "detail": "ignored: processing our own comment"}
 
-    # Bucket
-    bucket = _bucket_for(last, media_type)
-    log.info("Keyword scan: %r -> bucket=%s", last, bucket)
+    # Bucket: ISSUE_TYPE_AS_BUCKET => the Seerr issue TYPE drives the action and
+    # the comment is ignored; otherwise use the comment keyword scan (default).
+    if cfg.ISSUE_TYPE_AS_BUCKET:
+        bucket = _bucket_from_issue_type(enriched_payload.get("issue") or {})
+        log.info("Issue-type mode: issue_type -> bucket=%s", bucket)
+    else:
+        bucket = _bucket_for(last, media_type)
+        log.info("Keyword scan: %r -> bucket=%s", last, bucket)
 
     # No bucket → coach the user if coaching is enabled
     if not bucket:
+        # In issue-type mode the comment/keywords are irrelevant; don't post the
+        # keyword-coaching tip (it would be misleading).
+        if cfg.ISSUE_TYPE_AS_BUCKET:
+            log.info("Issue-type mode: no usable issue type; no action")
+            return {"ok": True, "detail": "ignored: no usable issue type"}
         log.info("No actionable keywords found")
         
         # Coaching: suggest keywords when none match, based on issue type

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import os
+
+# app.config builds a Settings() at import time with required integration fields
+# (SONARR_URL, etc.). Provide dummies so importing the modules under test does
+# not fail during collection.
+for _k, _v in {
+    "SONARR_URL": "http://sonarr:8989",
+    "SONARR_API_KEY": "x",
+    "RADARR_URL": "http://radarr:7878",
+    "RADARR_API_KEY": "x",
+    "JELLYSEERR_URL": "http://seerr:5055",
+    "JELLYSEERR_API_KEY": "x",
+}.items():
+    os.environ.setdefault(_k, _v)

--- a/tests/test_bucket_from_issue_type.py
+++ b/tests/test_bucket_from_issue_type.py
@@ -1,0 +1,37 @@
+"""Tests for ISSUE_TYPE_AS_BUCKET — deriving the bucket from the Seerr issue TYPE."""
+
+from app.webhooks.handlers import _bucket_from_issue_type
+
+
+def test_body_string_wins():
+    assert _bucket_from_issue_type({"issue_type": "Audio"}) == "audio"
+    assert _bucket_from_issue_type({"issue_type": "video"}) == "video"
+    assert _bucket_from_issue_type({"issue_type": "SUBTITLE"}) == "subtitle"
+    assert _bucket_from_issue_type({"issue_type": "other"}) == "other"
+
+
+def test_int_fallback():
+    assert _bucket_from_issue_type({"issueType": 1}) == "video"
+    assert _bucket_from_issue_type({"issueType": 2}) == "audio"
+    assert _bucket_from_issue_type({"issueType": 3}) == "subtitle"
+    assert _bucket_from_issue_type({"issueType": 4}) == "other"
+
+
+def test_body_string_preferred_over_int():
+    assert _bucket_from_issue_type({"issue_type": "audio", "issueType": 1}) == "audio"
+
+
+def test_invalid_and_empty():
+    assert _bucket_from_issue_type({}) is None
+    assert _bucket_from_issue_type({"issue_type": "wrong"}) is None
+    assert _bucket_from_issue_type({"issue_type": ""}) is None
+    assert _bucket_from_issue_type({"issueType": 99}) is None
+    assert _bucket_from_issue_type({"issueType": None}) is None
+
+
+def test_string_is_normalized_and_bool_int_is_ignored():
+    # Surrounding whitespace / casing are tolerated on the string path...
+    assert _bucket_from_issue_type({"issue_type": "  Audio  "}) == "audio"
+    # ...and a bool must not be treated as its int value (True == 1 in Python).
+    assert _bucket_from_issue_type({"issueType": True}) is None
+    assert _bucket_from_issue_type({"issueType": False}) is None


### PR DESCRIPTION
## Summary
Adds an off-by-default **`ISSUE_TYPE_AS_BUCKET`** flag so the remediation action is chosen from the Overseerr/Jellyseerr issue **Type** (Audio / Video / Subtitle / Other) instead of scanning the comment for keywords.

## Motivation
Users describe problems in their own words ("has a narrator", "sound is off") that rarely match the configured keyword lists, so a correctly-typed issue often does nothing. The **Type** the user already selects is a reliable signal on its own.

## Behavior
- **Flag off (default):** unchanged — comment-keyword matching as today.
- **Flag on:** the issue Type drives the bucket and the comment is ignored:
  - Audio / Video / Subtitle → delete the file + re-search
  - Other → search only (no delete)
  - The `*_KEYWORDS` lists are inert while on.
- Bucket is derived from the webhook body string `issue_type` (preferred) or the API integer `issueType` (fallback, mapped per the upstream `IssueType` enum).

## Tests
Adds a pytest workflow (`.github/workflows/tests.yml`) and unit tests for the mapping (string normalization, int fallback, bool/None guards).

## Checklist
- [x] Off-by-default; existing behavior unchanged
- [x] `.env.example` updated
- [x] Tests added
- [x] README updated
