### PR TITLE
Genericize Jellyseerr env vars to SEERR_* (Seerr support)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,25 +64,30 @@ RADARR_API_KEY=
 # Increase if you have a slow Radarr instance or large library  
 RADARR_HTTP_TIMEOUT=60
 
-# ====== JELLYSEERR INTEGRATION ======
-# Jellyseerr base URL (include http:// or https://)
-# Use container name if running in Docker: http://jellyseerr:5055
+# ====== SEERR INTEGRATION (Jellyseerr / Seerr / Overseerr-based apps) ======
+# Works with Jellyseerr and Seerr — they speak the same API. Legacy
+# JELLYSEERR_URL / JELLYSEERR_API_KEY / JELLYSEERR_CLOSE_ISSUES /
+# JELLYSEERR_COMMENT_ON_ACTION / JELLYSEERR_BOT_COMMENT_PREFIX still work if
+# you already have those set — SEERR_* just takes precedence when both are set.
+#
+# Base URL (include http:// or https://)
+# Use container name if running in Docker: http://seerr:5055
 # Use localhost if running locally: http://localhost:5055
-JELLYSEERR_URL=http://jellyseerr:5055
+SEERR_URL=http://seerr:5055
 
-# Jellyseerr API key from Settings > General > API Key
+# API key from Settings > General > API Key
 # Required for: fetching issue details, posting comments, closing issues
-JELLYSEERR_API_KEY=
+SEERR_API_KEY=
 
 # Automatically close issues after successful remediation
 # true: Close issues after fixing and posting success comment (recommended)
 # false: Only post comment, leave issue open for manual closure
-JELLYSEERR_CLOSE_ISSUES=true
+SEERR_CLOSE_ISSUES=true
 
 # Post comments when actions are taken
 # true: Post comments explaining what was done (recommended)
 # false: Take actions silently without commenting
-JELLYSEERR_COMMENT_ON_ACTION=true
+SEERR_COMMENT_ON_ACTION=true
 
 # Derive the remediation action from the Jellyseerr/Overseerr issue TYPE
 # (Audio/Video/Subtitle/Other) instead of scanning the comment for keywords.
@@ -259,7 +264,7 @@ MSG_COACH=
 # These settings are for advanced users and rarely need changing
 
 # Custom bot prefix for comments (changing this may break loop detection)
-# JELLYSEERR_BOT_COMMENT_PREFIX=[Remediarr]
+# SEERR_BOT_COMMENT_PREFIX=[Remediarr]
 
 # HTTP retry settings for external API calls
 # HTTP_MAX_RETRIES=3
@@ -289,8 +294,8 @@ STARTUP_HEALTH_CHECK_DELAY=10
 # SONARR_API_KEY=abc123
 # RADARR_URL=http://radarr:7878
 # RADARR_API_KEY=def456
-# JELLYSEERR_URL=http://jellyseerr:5055
-# JELLYSEERR_API_KEY=ghi789
+# SEERR_URL=http://seerr:5055
+# SEERR_API_KEY=ghi789
 
 # === SECURE SETUP ===
 # Add webhook security:
@@ -311,7 +316,7 @@ STARTUP_HEALTH_CHECK_DELAY=10
 ########################################
 
 # Issue: "Missing tvdbId/season/episode" errors
-# Solution: Verify Jellyseerr webhook payload includes all template variables
+# Solution: Verify Jellyseerr/Seerr webhook payload includes all template variables
 #          Check that issues are reported with season/episode information
 
 # Issue: Actions not working
@@ -320,12 +325,12 @@ STARTUP_HEALTH_CHECK_DELAY=10
 #          Ensure Sonarr/Radarr can access media files
 
 # Issue: Webhook loops
-# Solution: Only enable "Issue Reported" in Jellyseerr webhook settings
+# Solution: Only enable "Issue Reported" in Jellyseerr/Seerr webhook settings
 #          Don't enable "Issue Comment" or other event types
 
 # Issue: Issues not closing automatically
-# Solution: Some Jellyseerr versions don't support auto-close API
-#          Set JELLYSEERR_CLOSE_ISSUES=false to disable attempts
+# Solution: Some Jellyseerr/Seerr versions don't support auto-close API
+#          Set SEERR_CLOSE_ISSUES=false to disable attempts
 
 # Issue: Keywords not matching
 # Solution: Check keyword spelling and case (keywords are case-insensitive)

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Remediarr is a lightweight webhook service that automatically fixes common media
 
 ## Features
 
+- **🔌 Jellyseerr & Seerr Support**: Both are supported out of the box — they share the same API (`SEERR_URL`/`SEERR_API_KEY`)
 - **🎬 Movie Automation**: Handles audio, video, subtitle issues, and wrong movie downloads
 - **📺 TV Show Automation**: Manages episode-specific problems with season/episode detection  
 - **🤖 Smart Keyword Detection**: Recognizes issue types from user comments
-- **🏷️ Type-Driven Mode** *(opt-in)*: Let the Jellyseerr issue **Type** pick the action — no keywords needed (`ISSUE_TYPE_AS_BUCKET`)
+- **🏷️ Type-Driven Mode** *(opt-in)*: Let the Jellyseerr/Seerr issue **Type** pick the action — no keywords needed (`ISSUE_TYPE_AS_BUCKET`)
 - **✅ Confirm-on-Import** *(opt-in)*: Hold the issue open until Sonarr confirms the replacement imported — it closes only when the file is actually on disk (`CONFIRM_REPLACEMENT_IMPORT`)
 - **💬 User Coaching**: Suggests correct keywords when users don't use recognizable terms
 - **🔄 Loop Prevention**: Avoids processing its own comments and resolved issues
@@ -160,7 +161,7 @@ When `CONFIRM_REPLACEMENT_IMPORT` is enabled, Remediarr needs Sonarr to notify i
    - ✅ **On Import**
    - ✅ **On Upgrade**
    - ✅ **On Import Complete**
-5. If you have `WEBHOOK_HEADER_NAME` and `WEBHOOK_HEADER_VALUE` set, add the same header under **Advanced → Headers** in Sonarr. This is the only auth available on this endpoint — the HMAC secret used by Jellyseerr does not apply here as Sonarr Connect does not support it.
+5. If you have `WEBHOOK_HEADER_NAME` and `WEBHOOK_HEADER_VALUE` set, add the same header under **Advanced → Headers** in Sonarr. This is the only auth available on this endpoint — the HMAC secret used by Jellyseerr/Seerr does not apply here as Sonarr Connect does not support it.
 6. Save and use the **Test** button to verify Sonarr can reach Remediarr.
 
 > **Note:** Remediarr must be running as a single worker. If you run multiple workers (e.g. `gunicorn --workers 2`), pending import state is not shared between them and issues may not close correctly.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Configure webhooks in **Jellyseerr/Seerr → Settings → Notifications → Webh
 
 ### Webhook Settings
 - **Webhook URL**: `http://your-server:8189/webhook/jellyseerr`
+  - Yes, the path says `jellyseerr` even if you're running Seerr — the endpoint name wasn't changed to avoid breaking existing webhook configs, but it works identically for both.
 - **Request Method**: `POST`
 - **Notification Types**: Check **only** "Issue Reported" (other types will cause loops)
 
@@ -271,7 +272,7 @@ APPRISE_URLS="discord://webhook_id/webhook_token,slack://hook_url"
 - `GET /` - Basic status and version info
 - `GET /health` - Simple health check  
 - `GET /health/detailed` - Health check including external services
-- `POST /webhook/jellyseerr` - Main webhook endpoint
+- `POST /webhook/jellyseerr` - Main webhook endpoint (this path name is unchanged for backward compat, but it's the correct endpoint for Seerr too — Jellyseerr and Seerr send the same payload)
 - `POST /webhook/sonarr` - Sonarr "On Import" webhook (used only when `CONFIRM_REPLACEMENT_IMPORT=true`)
 - `POST /webhook/radarr` - Radarr "On Import" webhook (used only when `CONFIRM_REPLACEMENT_IMPORT=true`)
 - `GET /docs` - Interactive API documentation

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Remediarr
 
-**Automated issue resolution for Jellyseerr via Sonarr & Radarr webhooks**
+**Automated issue resolution for Jellyseerr/Seerr via Sonarr & Radarr webhooks**
 
 > ⚠️ **Work in Progress**: Remediarr is under active development. Configuration options, API endpoints, and behavior may change between versions. Please check the changelog and update your configuration when upgrading. Feedback and bug reports are welcome!
 
-Remediarr is a lightweight webhook service that automatically fixes common media issues reported through Jellyseerr. When users report problems like "no audio" or "wrong movie", Remediarr detects the keywords, deletes problematic files, triggers new downloads, and closes the issue—all without manual intervention.
+Remediarr is a lightweight webhook service that automatically fixes common media issues reported through Jellyseerr or Seerr (they share the same API, so both are supported). When users report problems like "no audio" or "wrong movie", Remediarr detects the keywords, deletes problematic files, triggers new downloads, and closes the issue—all without manual intervention.
 
 ## Features
 
@@ -51,8 +51,8 @@ services:
       - SONARR_API_KEY=your-sonarr-api-key
       - RADARR_URL=http://radarr:7878  
       - RADARR_API_KEY=your-radarr-api-key
-      - JELLYSEERR_URL=http://jellyseerr:5055
-      - JELLYSEERR_API_KEY=your-jellyseerr-api-key
+      - SEERR_URL=http://seerr:5055
+      - SEERR_API_KEY=your-seerr-api-key
       
       # Optional - Bazarr subtitle integration
       - BAZARR_URL=http://bazarr:6767
@@ -78,16 +78,16 @@ docker run -d \
   -e SONARR_API_KEY=your-api-key \
   -e RADARR_URL=http://radarr:7878 \
   -e RADARR_API_KEY=your-api-key \
-  -e JELLYSEERR_URL=http://jellyseerr:5055 \
-  -e JELLYSEERR_API_KEY=your-api-key \
+  -e SEERR_URL=http://seerr:5055 \
+  -e SEERR_API_KEY=your-api-key \
   -e BAZARR_URL=http://bazarr:6767 \
   -e BAZARR_API_KEY=your-api-key \
   ghcr.io/sbcrumb/remediarr:latest
 ```
 
-## Jellyseerr Configuration
+## Jellyseerr/Seerr Configuration
 
-Configure webhooks in **Jellyseerr → Settings → Notifications → Webhooks**:
+Configure webhooks in **Jellyseerr/Seerr → Settings → Notifications → Webhooks**:
 
 ### Webhook Settings
 - **Webhook URL**: `http://your-server:8189/webhook/jellyseerr`
@@ -134,8 +134,8 @@ Remediarr is configured entirely through environment variables. See the [complet
 | `SONARR_API_KEY` | Sonarr API key | `abc123...` |
 | `RADARR_URL` | Radarr base URL | `http://radarr:7878` |
 | `RADARR_API_KEY` | Radarr API key | `def456...` |
-| `JELLYSEERR_URL` | Jellyseerr base URL | `http://jellyseerr:5055` |
-| `JELLYSEERR_API_KEY` | Jellyseerr API key | `ghi789...` |
+| `SEERR_URL` | Jellyseerr/Seerr base URL (legacy `JELLYSEERR_URL` still works) | `http://seerr:5055` |
+| `SEERR_API_KEY` | Jellyseerr/Seerr API key (legacy `JELLYSEERR_API_KEY` still works) | `ghi789...` |
 
 ### Optional Settings
 
@@ -143,7 +143,7 @@ Remediarr is configured entirely through environment variables. See the [complet
 |----------|-------------|---------|
 | `BAZARR_URL` | Bazarr base URL (for subtitle management) | `http://bazarr:6767` |
 | `BAZARR_API_KEY` | Bazarr API key | `jkl012...` |
-| `ISSUE_TYPE_AS_BUCKET` | When `true`, the Jellyseerr issue **Type** (Audio/Video/Subtitle/Other) drives the action and the **comment is ignored** — users can report an issue by type alone with no keywords required. Audio/Video/Subtitle → delete + re-search; Other → search only. The `*_KEYWORDS` lists are unused while this is on. Default `false`. | `false` |
+| `ISSUE_TYPE_AS_BUCKET` | When `true`, the Jellyseerr/Seerr issue **Type** (Audio/Video/Subtitle/Other) drives the action and the **comment is ignored** — users can report an issue by type alone with no keywords required. Audio/Video/Subtitle → delete + re-search; Other → search only. The `*_KEYWORDS` lists are unused while this is on. Default `false`. | `false` |
 | `CONFIRM_REPLACEMENT_IMPORT` | When `true`, Remediarr holds an issue open after triggering a re-download and only comments + closes once the replacement is confirmed imported. TV issues wait for Sonarr's On Import webhook; movie issues wait for Radarr's. If the download never lands, the issue stays open as a signal for manual follow-up. Requires the webhook setup below for each arr you want to confirm. Default `false`. | `false` |
 
 #### Setting up the Sonarr webhook (required for `CONFIRM_REPLACEMENT_IMPORT=true`)
@@ -280,21 +280,21 @@ APPRISE_URLS="discord://webhook_id/webhook_token,slack://hook_url"
 ### Common Issues
 
 **"Missing tvdbId/season/episode" error**
-- Ensure your Jellyseerr webhook payload includes all the template variables
+- Ensure your Jellyseerr/Seerr webhook payload includes all the template variables
 - Check that the issue was reported with season/episode information
 
 **Issues not auto-closing**
-- Some Jellyseerr versions don't support the close API endpoint
-- Disable with `JELLYSEERR_CLOSE_ISSUES=false` if needed
+- Some Jellyseerr/Seerr versions don't support the close API endpoint
+- Disable with `SEERR_CLOSE_ISSUES=false` if needed
 - Remediarr will still comment when actions are taken
 
 **Webhook loops**  
-- Only enable "Issue Reported" in Jellyseerr webhook settings
+- Only enable "Issue Reported" in Jellyseerr/Seerr webhook settings
 - Don't enable "Issue Comment" or other event types
 
 **Files not found in Sonarr/Radarr**
 - Verify the content exists in your *arr apps
-- Check that TVDB/TMDB IDs match between Jellyseerr and your *arr apps
+- Check that TVDB/TMDB IDs match between Jellyseerr/Seerr and your *arr apps
 
 ### Debug Mode
 ```bash

--- a/SETUP.md
+++ b/SETUP.md
@@ -6,7 +6,7 @@ This guide walks you through setting up Remediarr step-by-step.
 
 Before setting up Remediarr, ensure you have:
 
-- **Jellyseerr** running and configured
+- **Jellyseerr** or **Seerr** running and configured (they share the same API, so either works)
 - **Sonarr** running with TV shows imported
 - **Radarr** running with movies imported  
 - **Docker** or **Python 3.11+** installed
@@ -24,8 +24,8 @@ Before setting up Remediarr, ensure you have:
 2. Go to **Settings → General → Security**
 3. Copy the **API Key**
 
-### Jellyseerr API Key
-1. Open Jellyseerr web interface  
+### Jellyseerr / Seerr API Key
+1. Open your Jellyseerr or Seerr web interface
 2. Go to **Settings → General**
 3. Copy the **API Key** (generate one if needed)
 
@@ -49,8 +49,8 @@ services:
       - SONARR_API_KEY=your-sonarr-api-key-here
       - RADARR_URL=http://radarr:7878
       - RADARR_API_KEY=your-radarr-api-key-here
-      - JELLYSEERR_URL=http://jellyseerr:5055
-      - JELLYSEERR_API_KEY=your-jellyseerr-api-key-here
+      - SEERR_URL=http://seerr:5055
+      - SEERR_API_KEY=your-seerr-api-key-here
       
       # Optional: Enable debug logging for initial testing
       - LOG_LEVEL=DEBUG
@@ -72,16 +72,16 @@ SONARR_URL=http://localhost:8989
 SONARR_API_KEY=your-sonarr-api-key-here
 RADARR_URL=http://localhost:7878  
 RADARR_API_KEY=your-radarr-api-key-here
-JELLYSEERR_URL=http://localhost:5055
-JELLYSEERR_API_KEY=your-jellyseerr-api-key-here
+SEERR_URL=http://localhost:5055
+SEERR_API_KEY=your-seerr-api-key-here
 
 # Enable debug for testing
 LOG_LEVEL=DEBUG
 ```
 
-## Step 3: Configure Jellyseerr Webhook
+## Step 3: Configure Jellyseerr/Seerr Webhook
 
-1. Open Jellyseerr → **Settings → Notifications → Webhooks**
+1. Open Jellyseerr/Seerr → **Settings → Notifications → Webhooks**
 2. Click **Add Webhook**
 3. Configure:
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -91,6 +91,8 @@ LOG_LEVEL=DEBUG
 | **Request Method** | `POST` |
 | **Notification Types** | ✅ **Issue Reported** only |
 
+> Note: the path is `/webhook/jellyseerr` regardless of whether you're running Jellyseerr or Seerr — it's kept as-is so existing webhook configs don't break, and it works the same for both.
+
 4. **JSON Payload** - Copy this exactly:
 
 ```json

--- a/app/config.py
+++ b/app/config.py
@@ -5,10 +5,19 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Hard-coded to prevent loops and user customization
 BOT_PREFIX = "[Remediarr]"
+
+
+def env_alias(new_name: str, old_name: str, default: str = "") -> str:
+    """Read new_name, falling back to old_name for backward compat (e.g. SEERR_* vs legacy JELLYSEERR_*)."""
+    val = os.getenv(new_name)
+    if val is not None:
+        return val
+    return os.getenv(old_name, default)
 
 
 def _detect_version() -> str:
@@ -67,8 +76,10 @@ class Settings(BaseSettings):
     RADARR_API_KEY: str
     RADARR_HTTP_TIMEOUT: int = 60
 
-    JELLYSEERR_URL: str
-    JELLYSEERR_API_KEY: str
+    # SEERR_* is the canonical name; JELLYSEERR_* is accepted for backward
+    # compat since Jellyseerr/Seerr/Overseerr-based apps all speak the same API.
+    SEERR_URL: str = Field(validation_alias=AliasChoices("SEERR_URL", "JELLYSEERR_URL"))
+    SEERR_API_KEY: str = Field(validation_alias=AliasChoices("SEERR_API_KEY", "JELLYSEERR_API_KEY"))
 
     BAZARR_URL: Optional[str] = None
     BAZARR_API_KEY: Optional[str] = None
@@ -77,8 +88,8 @@ class Settings(BaseSettings):
     BAZARR_FORCE_REDOWNLOAD: bool = False
 
     # ===== Behavior toggles =====
-    JELLYSEERR_CLOSE_ISSUES: bool = True
-    JELLYSEERR_COMMENT_ON_ACTION: bool = True
+    SEERR_CLOSE_ISSUES: bool = Field(default=True, validation_alias=AliasChoices("SEERR_CLOSE_ISSUES", "JELLYSEERR_CLOSE_ISSUES"))
+    SEERR_COMMENT_ON_ACTION: bool = Field(default=True, validation_alias=AliasChoices("SEERR_COMMENT_ON_ACTION", "JELLYSEERR_COMMENT_ON_ACTION"))
     # When true, the Seerr issue TYPE (audio/video/subtitle/other) drives the
     # remediation action and the comment is ignored. OFF by default.
     ISSUE_TYPE_AS_BUCKET: bool = False

--- a/app/services/jellyseerr.py
+++ b/app/services/jellyseerr.py
@@ -3,11 +3,13 @@ import logging
 from typing import Any, Dict, Optional, Tuple, List
 import httpx
 
+from app.config import env_alias
+
 log = logging.getLogger("remediarr")
 
-BASE = os.getenv("JELLYSEERR_URL", "").rstrip("/")
-API_KEY = os.getenv("JELLYSEERR_API_KEY", "")
-PREFIX = os.getenv("JELLYSEERR_BOT_COMMENT_PREFIX", "[Remediarr]")
+BASE = env_alias("SEERR_URL", "JELLYSEERR_URL").rstrip("/")
+API_KEY = env_alias("SEERR_API_KEY", "JELLYSEERR_API_KEY")
+PREFIX = env_alias("SEERR_BOT_COMMENT_PREFIX", "JELLYSEERR_BOT_COMMENT_PREFIX", "[Remediarr]")
 
 _headers = {"X-Api-Key": API_KEY} if API_KEY else {}
 

--- a/app/services/jellyseerr.py
+++ b/app/services/jellyseerr.py
@@ -1,4 +1,3 @@
-import os
 import logging
 from typing import Any, Dict, Optional, Tuple, List
 import httpx

--- a/app/webhooks/handlers.py
+++ b/app/webhooks/handlers.py
@@ -12,14 +12,14 @@ from app.services import radarr as R
 from app.services import sonarr as S
 from app.services import bazarr as B
 from app.services.notify import notify
-from app.config import cfg
+from app.config import cfg, env_alias
 
 log = logging.getLogger("remediarr")
 
 # env/config
-PREFIX = os.getenv("JELLYSEERR_BOT_COMMENT_PREFIX", "[Remediarr]")
-CLOSE_ISSUES = os.getenv("JELLYSEERR_CLOSE_ISSUES", "true").lower() == "true"
-COMMENT_ON_ACTION = os.getenv("JELLYSEERR_COMMENT_ON_ACTION", "true").lower() == "true"
+PREFIX = env_alias("SEERR_BOT_COMMENT_PREFIX", "JELLYSEERR_BOT_COMMENT_PREFIX", "[Remediarr]")
+CLOSE_ISSUES = env_alias("SEERR_CLOSE_ISSUES", "JELLYSEERR_CLOSE_ISSUES", "true").lower() == "true"
+COMMENT_ON_ACTION = env_alias("SEERR_COMMENT_ON_ACTION", "JELLYSEERR_COMMENT_ON_ACTION", "true").lower() == "true"
 
 # Messages - Your requested format
 MSG_MOVIE_SUCCESS = os.getenv("MSG_MOVIE_SUCCESS", "{title}: replaced file; new download grabbed. Closing this issue. If anything's still off, comment and I'll take another pass.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ for _k, _v in {
     "SONARR_API_KEY": "x",
     "RADARR_URL": "http://radarr:7878",
     "RADARR_API_KEY": "x",
-    "JELLYSEERR_URL": "http://seerr:5055",
-    "JELLYSEERR_API_KEY": "x",
+    "SEERR_URL": "http://seerr:5055",
+    "SEERR_API_KEY": "x",
 }.items():
     os.environ.setdefault(_k, _v)

--- a/tests/test_config_seerr_alias.py
+++ b/tests/test_config_seerr_alias.py
@@ -1,10 +1,6 @@
 """SEERR_* is the canonical name; JELLYSEERR_* must keep working for existing
 setups (Jellyseerr/Seerr/Overseerr-based apps all speak the same API)."""
 
-import os
-
-import pytest
-
 from app.config import Settings, env_alias
 
 BASE_ENV = {

--- a/tests/test_config_seerr_alias.py
+++ b/tests/test_config_seerr_alias.py
@@ -1,0 +1,70 @@
+"""SEERR_* is the canonical name; JELLYSEERR_* must keep working for existing
+setups (Jellyseerr/Seerr/Overseerr-based apps all speak the same API)."""
+
+import os
+
+import pytest
+
+from app.config import Settings, env_alias
+
+BASE_ENV = {
+    "SONARR_URL": "http://sonarr:8989",
+    "SONARR_API_KEY": "x",
+    "RADARR_URL": "http://radarr:7878",
+    "RADARR_API_KEY": "x",
+}
+
+
+def _settings(monkeypatch, **extra):
+    # conftest.py sets SEERR_URL/SEERR_API_KEY globally so importing app.config
+    # doesn't fail during collection; clear those so each test controls exactly
+    # which var(s) are present.
+    monkeypatch.delenv("SEERR_URL", raising=False)
+    monkeypatch.delenv("SEERR_API_KEY", raising=False)
+    monkeypatch.delenv("JELLYSEERR_URL", raising=False)
+    monkeypatch.delenv("JELLYSEERR_API_KEY", raising=False)
+    for k, v in {**BASE_ENV, **extra}.items():
+        monkeypatch.setenv(k, v)
+    return Settings()
+
+
+def test_seerr_name_works(monkeypatch):
+    s = _settings(monkeypatch, SEERR_URL="http://seerr:5055", SEERR_API_KEY="key1")
+    assert s.SEERR_URL == "http://seerr:5055"
+    assert s.SEERR_API_KEY == "key1"
+
+
+def test_legacy_jellyseerr_name_still_works(monkeypatch):
+    s = _settings(monkeypatch, JELLYSEERR_URL="http://jellyseerr:5055", JELLYSEERR_API_KEY="key2")
+    assert s.SEERR_URL == "http://jellyseerr:5055"
+    assert s.SEERR_API_KEY == "key2"
+
+
+def test_seerr_name_takes_precedence_when_both_set(monkeypatch):
+    s = _settings(
+        monkeypatch,
+        SEERR_URL="http://new:5055",
+        SEERR_API_KEY="newkey",
+        JELLYSEERR_URL="http://old:5055",
+        JELLYSEERR_API_KEY="oldkey",
+    )
+    assert s.SEERR_URL == "http://new:5055"
+    assert s.SEERR_API_KEY == "newkey"
+
+
+def test_env_alias_helper_prefers_new_name(monkeypatch):
+    monkeypatch.setenv("SEERR_BOT_COMMENT_PREFIX", "[New]")
+    monkeypatch.setenv("JELLYSEERR_BOT_COMMENT_PREFIX", "[Old]")
+    assert env_alias("SEERR_BOT_COMMENT_PREFIX", "JELLYSEERR_BOT_COMMENT_PREFIX") == "[New]"
+
+
+def test_env_alias_helper_falls_back_to_old_name(monkeypatch):
+    monkeypatch.delenv("SEERR_BOT_COMMENT_PREFIX", raising=False)
+    monkeypatch.setenv("JELLYSEERR_BOT_COMMENT_PREFIX", "[Old]")
+    assert env_alias("SEERR_BOT_COMMENT_PREFIX", "JELLYSEERR_BOT_COMMENT_PREFIX") == "[Old]"
+
+
+def test_env_alias_helper_default(monkeypatch):
+    monkeypatch.delenv("SEERR_BOT_COMMENT_PREFIX", raising=False)
+    monkeypatch.delenv("JELLYSEERR_BOT_COMMENT_PREFIX", raising=False)
+    assert env_alias("SEERR_BOT_COMMENT_PREFIX", "JELLYSEERR_BOT_COMMENT_PREFIX", "[Remediarr]") == "[Remediarr]"


### PR DESCRIPTION
## Summary
- Jellyseerr and Seerr share the same API, so the `JELLYSEERR_*` env var naming was misleading for Seerr users (see #92). `SEERR_URL`/`SEERR_API_KEY`/`SEERR_CLOSE_ISSUES`/`SEERR_COMMENT_ON_ACTION`/`SEERR_BOT_COMMENT_PREFIX` are now canonical.
- `JELLYSEERR_*` still works as a fallback via a shared `env_alias()` helper (and pydantic `AliasChoices` in `Settings`), so existing setups don't break.
- Docs (README/SETUP.md/.env.example) updated to document both, including a note that the `/webhook/jellyseerr` route path is intentionally unchanged (still correct for Seerr too) to avoid breaking existing webhook configs.

## Test plan
- [x] `pytest` — 32 passed, including new `tests/test_config_seerr_alias.py` covering: `SEERR_*` works, legacy `JELLYSEERR_*` still works, `SEERR_*` takes precedence when both are set, and the `env_alias()` helper directly
- [x] Manually verified both `SEERR_*`-only and `JELLYSEERR_*`-only env configs resolve `cfg.SEERR_URL` / `jellyseerr.BASE` / `jellyseerr.API_KEY` correctly