### PR TITLE
ci: add ruff + vulture linting to catch dead/duplicate code

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,3 +14,38 @@ jobs:
           python-version: "3.11"
       - run: pip install -r requirements.txt pytest
       - run: python -m pytest -q
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install ruff vulture
+
+      # Pyflakes rules only (unused imports, redefined names/functions,
+      # undefined names) — catches duplicate/orphaned code, not style.
+      # TODO: drop `continue-on-error` once the existing findings on `dev`
+      # (duplicate imports in health.py, duplicate handlers in handlers.py)
+      # are cleaned up, then make this required.
+      - name: ruff (pyflakes)
+        continue-on-error: true
+        run: ruff check --select F app tests
+
+      # Flags functions/modules with no call sites anywhere in the repo.
+      # TODO: drop `continue-on-error` once the existing dead modules
+      # (messages.py, keyword_matcher.py, domain/keywords.py, http.py's
+      # retry_http, etc.) are removed, then make this required.
+      - name: vulture (dead code)
+        continue-on-error: true
+        run: vulture app tests vulture_whitelist.py --exclude "app/config.py"
+
+      # Catches AI-editor diff placeholders left in committed source (e.g.
+      # "...existing code..."), which silently break whatever function they
+      # land in. TODO: drop `continue-on-error` once the existing hit in
+      # messages.py is cleaned up, then make this required.
+      - name: no leftover AI-editor placeholders
+        continue-on-error: true
+        run: |
+          ! grep -rn --include="*.py" -E '\.\.\.\s*existing code|<<<<<<<|>>>>>>>|^=======$' app tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.ruff]
+target-version = "py311"
+
+[tool.ruff.lint]
+# Pyflakes only: unused imports, redefined names/functions, undefined names,
+# unused variables. This is what catches duplicate function definitions and
+# orphaned modules — not a style/formatting linter, so it won't fight the
+# existing code style.
+select = ["F"]
+
+[tool.vulture]
+min_confidence = 60
+paths = ["app", "tests"]
+exclude = ["vulture_whitelist.py"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pytest
+ruff
+vulture

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -1,0 +1,12 @@
+# Vulture false positives: these are only referenced via FastAPI route/event
+# decorators or pytest autouse fixtures, so vulture can't see they're used.
+# This file is NOT for silencing genuinely dead code — real orphaned
+# functions/modules should be deleted, not whitelisted.
+root  # app/main.py — FastAPI route
+health  # app/main.py — FastAPI route
+health_detailed  # app/main.py — FastAPI route
+on_startup  # app/main.py — FastAPI startup event
+jellyseerr_webhook  # app/webhooks/router.py — FastAPI route
+sonarr_webhook  # app/webhooks/router.py — FastAPI route
+radarr_webhook  # app/webhooks/router.py — FastAPI route
+_clean_pending  # tests/test_router_auth.py — pytest autouse fixture


### PR DESCRIPTION
## Summary
- Adds a `lint` CI job running `ruff check --select F` (unused imports, redefined names/functions, undefined names) and `vulture` (dead functions/modules), plus a grep guard for leftover AI-editor diff placeholders (e.g. "...existing code...").
- Both linters currently have real findings on `dev` (duplicate imports in `health.py`, several dead modules/functions, duplicate function definitions in `handlers.py`), so they're wired up as `continue-on-error` for now. A follow-up cleanup PR will remove those findings and this can be flipped to a required check.
- `requirements-dev.txt` and `vulture_whitelist.py` let contributors run the same checks locally; the whitelist only covers FastAPI route handlers and a pytest autouse fixture, which vulture can't see are used since they're only referenced via decorators.

## Test plan
- [x] Verified locally against `dev`: ruff/vulture/placeholder-grep all correctly silent when clean, correctly flag the known pre-existing issues, no false positives from the whitelist
- [x] `pytest` — 32 passed