### PR TITLE
Handle 'All Seasons' (problemSeason=0) TV issue reports

### DIFF
--- a/app/services/sonarr.py
+++ b/app/services/sonarr.py
@@ -80,3 +80,15 @@ async def trigger_season_search(series_id: int, season: int) -> None:
     r = await _client_lazy().post(f"{API}/command", headers=HEADERS, json=body)
     r.raise_for_status()
 
+async def get_seasons_with_files(series_id: int) -> set[int]:
+    """Return the set of season numbers (excluding season 0/specials) that
+    have at least one episode file on disk. One Sonarr fetch; callers derive
+    both "how many" and "which one" from the same result instead of each
+    re-fetching the episode list."""
+    eps = await list_episodes(series_id)
+    seasons: set[int] = set()
+    for e in eps:
+        sn = e.get("seasonNumber")
+        if isinstance(sn, int) and sn > 0 and e.get("hasFile"):
+            seasons.add(sn)
+    return seasons

--- a/app/webhooks/handlers.py
+++ b/app/webhooks/handlers.py
@@ -17,14 +17,16 @@ log = logging.getLogger("remediarr")
 
 
 class AllSeasonsAmbiguousError(ValueError):
-    """Issue targets 'All Seasons' and we cannot safely pick one."""
+    """Issue targets 'All Seasons' and we cannot safely pick one season
+    (season_count=0: nothing has files; season_count>1: too destructive)."""
     def __init__(self, season_count: int, title: str):
         self.season_count = season_count
         self.title = title
-        super().__init__(
-            f"All Seasons selected for '{title}' "
-            f"({season_count} seasons have files — too destructive)."
-        )
+        if season_count == 0:
+            reason = "no seasons have files — nothing to remediate"
+        else:
+            reason = f"{season_count} seasons have files — too destructive"
+        super().__init__(f"All Seasons selected for '{title}' ({reason}).")
 
 
 # env/config
@@ -446,34 +448,37 @@ async def _tv_episode_from_payload(payload: Dict[str, Any]) -> Tuple[int, Dict[s
         raise ValueError("Series not found in Sonarr")
 
     # --- "All Seasons" sentinel (problemSeason=0) ---
-    # The reporter sends season=0 when the user picks "All Seasons". That could
-    # mean deleting every episode file on disk — too destructive to do blindly.
-    # Instead, count how many seasons actually have files:
-    #   1 season  → auto-target that one
-    #   >1 season → refuse and leave a comment explaining why
-    #   0 seasons → nothing to fix, skip gracefully
-    if season == 0:
+    # The reporter sends season=0 both when the user picks "All Seasons" AND
+    # when they report a specific episode within season 0 ("Specials") — the
+    # payload alone can't tell these apart. Only treat it as the "All Seasons"
+    # sentinel when there's no specific episode number attached; a real
+    # Specials episode report (season=0, episode=<N>) falls through untouched
+    # and is handled like any other specific-episode report.
+    if season == 0 and (all_episodes_in_season or episode is None):
         title = series.get("title") or f"Series {series['id']}"
-        only_season = await S.get_only_season_with_files(series["id"])
-        if only_season is not None:
-            season = only_season
+        # That could mean deleting every episode file on disk — too destructive
+        # to do blindly. Instead, look at how many seasons actually have files:
+        #   1 season  → auto-target that one
+        #   >1 season → refuse and leave a comment explaining why
+        #   0 seasons → nothing to fix, comment + close
+        seasons_with_files = await S.get_seasons_with_files(series["id"])
+        if len(seasons_with_files) == 1:
+            season = next(iter(seasons_with_files))
             log.info(
                 "All Seasons selected for '%s' but only season %s has files — auto-targeting",
                 title, season,
             )
         else:
-            count = await S.count_seasons_with_files(series["id"])
-            if count == 0:
-                raise ValueError(
-                    f"No episode files on disk for '{title}' — nothing to remediate."
-                )
-            raise AllSeasonsAmbiguousError(count, title)
+            raise AllSeasonsAmbiguousError(len(seasons_with_files), title)
 
     if season is None:
         raise ValueError("Missing season number after all extraction attempts")
 
-    # Sanity check season
-    if season < 1 or season > 50:
+    # Sanity check season. 0 is allowed through here: it can only still be 0
+    # at this point if it's a genuine Specials report that skipped the
+    # "All Seasons" sentinel block above (that block always either
+    # reassigns season to a real number or raises before reaching here).
+    if season < 0 or season > 50:
         raise ValueError(f"Invalid season number: {season}")
 
     # All-episodes path: return episode=0 as sentinel
@@ -966,11 +971,19 @@ async def handle_jellyseerr(payload: Dict[str, Any]) -> Dict[str, Any]:
         except AllSeasonsAmbiguousError as e:
             log.info("TV extraction skipped: %s", e)
             if COMMENT_ON_ACTION:
-                msg = (
-                    f"{PREFIX} This issue targets **all {e.season_count} seasons** of "
-                    f"'{e.title}' — too destructive to remediate automatically. "
-                    f"Please file separate issues for specific seasons or episodes."
-                )
+                if e.season_count == 0:
+                    msg = (
+                        f"{PREFIX} All Seasons was reported for '{e.title}', but no "
+                        f"episode files were found on disk — nothing to remediate. If "
+                        f"specific episodes are missing, please report the specific "
+                        f"season/episode instead."
+                    )
+                else:
+                    msg = (
+                        f"{PREFIX} This issue targets **all {e.season_count} seasons** of "
+                        f"'{e.title}' — too destructive to remediate automatically. "
+                        f"Please file separate issues for specific seasons or episodes."
+                    )
                 await jelly_comment(issue_id, msg)
             if CLOSE_ISSUES:
                 closed = await jelly_close(issue_id)

--- a/app/webhooks/handlers.py
+++ b/app/webhooks/handlers.py
@@ -15,6 +15,18 @@ from app.config import cfg, env_alias
 
 log = logging.getLogger("remediarr")
 
+
+class AllSeasonsAmbiguousError(ValueError):
+    """Issue targets 'All Seasons' and we cannot safely pick one."""
+    def __init__(self, season_count: int, title: str):
+        self.season_count = season_count
+        self.title = title
+        super().__init__(
+            f"All Seasons selected for '{title}' "
+            f"({season_count} seasons have files — too destructive)."
+        )
+
+
 # env/config
 PREFIX = env_alias("SEERR_BOT_COMMENT_PREFIX", "JELLYSEERR_BOT_COMMENT_PREFIX", "[Remediarr]")
 CLOSE_ISSUES = env_alias("SEERR_CLOSE_ISSUES", "JELLYSEERR_CLOSE_ISSUES", "true").lower() == "true"
@@ -432,6 +444,30 @@ async def _tv_episode_from_payload(payload: Dict[str, Any]) -> Tuple[int, Dict[s
     series = await S.get_series_by_tvdb(int(tvdb_id))
     if not series:
         raise ValueError("Series not found in Sonarr")
+
+    # --- "All Seasons" sentinel (problemSeason=0) ---
+    # The reporter sends season=0 when the user picks "All Seasons". That could
+    # mean deleting every episode file on disk — too destructive to do blindly.
+    # Instead, count how many seasons actually have files:
+    #   1 season  → auto-target that one
+    #   >1 season → refuse and leave a comment explaining why
+    #   0 seasons → nothing to fix, skip gracefully
+    if season == 0:
+        title = series.get("title") or f"Series {series['id']}"
+        only_season = await S.get_only_season_with_files(series["id"])
+        if only_season is not None:
+            season = only_season
+            log.info(
+                "All Seasons selected for '%s' but only season %s has files — auto-targeting",
+                title, season,
+            )
+        else:
+            count = await S.count_seasons_with_files(series["id"])
+            if count == 0:
+                raise ValueError(
+                    f"No episode files on disk for '{title}' — nothing to remediate."
+                )
+            raise AllSeasonsAmbiguousError(count, title)
 
     if season is None:
         raise ValueError("Missing season number after all extraction attempts")
@@ -927,6 +963,19 @@ async def handle_jellyseerr(payload: Dict[str, Any]) -> Dict[str, Any]:
             series_id, series, season, episode = await _tv_episode_from_payload(enriched_payload)
             log.info("Successfully extracted TV context: series_id=%s, S%02d E%s",
                      series_id, season, "all" if episode == 0 else f"{episode:02d}")
+        except AllSeasonsAmbiguousError as e:
+            log.info("TV extraction skipped: %s", e)
+            if COMMENT_ON_ACTION:
+                msg = (
+                    f"{PREFIX} This issue targets **all {e.season_count} seasons** of "
+                    f"'{e.title}' — too destructive to remediate automatically. "
+                    f"Please file separate issues for specific seasons or episodes."
+                )
+                await jelly_comment(issue_id, msg)
+            if CLOSE_ISSUES:
+                closed = await jelly_close(issue_id)
+                log.info("Issue %s close attempt: %s", issue_id, "success" if closed else "failed")
+            return {"ok": True, "detail": f"ignored: {e}"}
         except (ValueError, Exception) as e:
             log.info("TV extraction failed: %s", str(e))
             return {"ok": True, "detail": f"ignored: {str(e)}"}

--- a/tests/test_all_seasons_season0.py
+++ b/tests/test_all_seasons_season0.py
@@ -1,0 +1,67 @@
+"""Tests for the 'All Seasons' sentinel (problemSeason=0) in _tv_episode_from_payload."""
+
+import asyncio
+
+import pytest
+
+from app.services import sonarr as S
+from app.webhooks import handlers as H
+
+
+SERIES = {"id": 42, "title": "Example Show"}
+
+
+def _payload():
+    return {
+        "issue": {"problemSeason": 0, "problemEpisode": 0},
+        "media": {"tvdbId": 12345},
+    }
+
+
+@pytest.fixture(autouse=True)
+def _stub_series(monkeypatch):
+    async def fake_get_series_by_tvdb(_tvdb_id):
+        return SERIES
+    monkeypatch.setattr(S, "get_series_by_tvdb", fake_get_series_by_tvdb)
+
+
+def _stub_episodes(monkeypatch, episodes):
+    async def fake_list_episodes(_series_id):
+        return episodes
+    monkeypatch.setattr(S, "list_episodes", fake_list_episodes)
+
+
+def test_single_season_with_files_is_auto_targeted(monkeypatch):
+    _stub_episodes(monkeypatch, [
+        {"seasonNumber": 0, "hasFile": True},   # specials are ignored
+        {"seasonNumber": 3, "hasFile": True},
+        {"seasonNumber": 4, "hasFile": False},
+    ])
+    series_id, series, season, episode = asyncio.run(
+        H._tv_episode_from_payload(_payload())
+    )
+    assert (series_id, season, episode) == (42, 3, 0)
+    assert series is SERIES
+
+
+def test_multiple_seasons_with_files_is_refused(monkeypatch):
+    _stub_episodes(monkeypatch, [
+        {"seasonNumber": 1, "hasFile": True},
+        {"seasonNumber": 2, "hasFile": True},
+        {"seasonNumber": 3, "hasFile": False},
+    ])
+    with pytest.raises(H.AllSeasonsAmbiguousError) as exc:
+        asyncio.run(H._tv_episode_from_payload(_payload()))
+    assert exc.value.season_count == 2
+    assert exc.value.title == "Example Show"
+
+
+def test_no_files_on_disk_is_skipped(monkeypatch):
+    _stub_episodes(monkeypatch, [
+        {"seasonNumber": 1, "hasFile": False},
+        {"seasonNumber": 2, "hasFile": False},
+    ])
+    with pytest.raises(ValueError) as exc:
+        asyncio.run(H._tv_episode_from_payload(_payload()))
+    assert not isinstance(exc.value, H.AllSeasonsAmbiguousError)
+    assert "nothing to remediate" in str(exc.value)

--- a/tests/test_all_seasons_season0.py
+++ b/tests/test_all_seasons_season0.py
@@ -56,12 +56,53 @@ def test_multiple_seasons_with_files_is_refused(monkeypatch):
     assert exc.value.title == "Example Show"
 
 
-def test_no_files_on_disk_is_skipped(monkeypatch):
+def test_no_files_on_disk_raises_ambiguous_with_zero_count(monkeypatch):
+    # Zero-count now goes through the same AllSeasonsAmbiguousError path as
+    # the >1 case, so the caller comments + closes consistently either way
+    # instead of silently ignoring the issue.
     _stub_episodes(monkeypatch, [
         {"seasonNumber": 1, "hasFile": False},
         {"seasonNumber": 2, "hasFile": False},
     ])
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(H.AllSeasonsAmbiguousError) as exc:
         asyncio.run(H._tv_episode_from_payload(_payload()))
-    assert not isinstance(exc.value, H.AllSeasonsAmbiguousError)
+    assert exc.value.season_count == 0
     assert "nothing to remediate" in str(exc.value)
+
+
+def test_season0_with_specific_episode_is_not_all_seasons_sentinel(monkeypatch):
+    # season=0 is also the real "Specials" season number, not just the "All
+    # Seasons" UI sentinel. A specific episode number means this is a genuine
+    # Specials report and must NOT be routed through the all-seasons logic —
+    # even when other seasons exist that would otherwise make it "ambiguous".
+    _stub_episodes(monkeypatch, [
+        {"seasonNumber": 1, "hasFile": True},
+        {"seasonNumber": 2, "hasFile": True},
+        {"seasonNumber": 0, "hasFile": True},
+    ])
+    payload = {
+        "issue": {"problemSeason": 0, "problemEpisode": 5},
+        "media": {"tvdbId": 12345},
+    }
+    series_id, series, season, episode = asyncio.run(
+        H._tv_episode_from_payload(payload)
+    )
+    assert (series_id, season, episode) == (42, 0, 5)
+
+
+def test_season0_specials_only_show_still_treated_as_all_seasons(monkeypatch):
+    # No specific episode given (episode=None, not the all-episodes sentinel
+    # either) alongside season=0 — still ambiguous-sentinel territory. Season
+    # 0 itself is excluded from the "seasons with files" count, so a
+    # specials-only show correctly reports "nothing to remediate" rather than
+    # silently targeting season 0.
+    _stub_episodes(monkeypatch, [
+        {"seasonNumber": 0, "hasFile": True},
+    ])
+    payload = {
+        "issue": {"problemSeason": 0},
+        "media": {"tvdbId": 12345},
+    }
+    with pytest.raises(H.AllSeasonsAmbiguousError) as exc:
+        asyncio.run(H._tv_episode_from_payload(payload))
+    assert exc.value.season_count == 0

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -10,3 +10,4 @@ jellyseerr_webhook  # app/webhooks/router.py — FastAPI route
 sonarr_webhook  # app/webhooks/router.py — FastAPI route
 radarr_webhook  # app/webhooks/router.py — FastAPI route
 _clean_pending  # tests/test_router_auth.py — pytest autouse fixture
+_stub_series  # tests/test_all_seasons_season0.py — pytest autouse fixture


### PR DESCRIPTION
Fixes the "All Seasons" case discussed in #92.

On v0.2.5, a season-wide report sends `problemSeason=0`. That value skips the
`if season == 0` handling (there is none) and falls straight through to:

    if season < 1 or season > 50:
        raise ValueError(f"Invalid season number: {season}")

so the issue is dropped with `Invalid season number: 0` and never remediated.

This resolves the sentinel against what is actually on disk instead of guessing:

| Seasons with files | Behaviour |
|---|---|
| exactly 1 | auto-target that season (the user's intent is unambiguous) |
| more than 1 | refuse, comment why, close the issue (honours `*_COMMENT_ON_ACTION` / `*_CLOSE_ISSUES`) |
| 0 | skip gracefully — nothing to remediate |

Season 0 (specials) is excluded from the counts.

No new config, no behaviour change for any report that already carries a real
season number. Includes 3 tests covering the three branches.