### PR TITLE
Add BLOCKLIST_ON_REPLACE: blocklist the bad release before re-searching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -155,6 +155,24 @@ ISSUE_TYPE_AS_BUCKET=false
 #     multi-worker deployment needs a shared store (not yet supported).
 CONFIRM_REPLACEMENT_IMPORT=false
 
+# Blocklist the bad release before deleting it, so the re-search can't grab the
+# exact same file again.
+# true:  before deleting a file, Remediarr marks the grab that produced it as
+#        FAILED in Radarr/Sonarr (the same thing the UI's "Mark as Failed" button
+#        does), which adds that release to the arr's Blocklist. The following
+#        search then skips it and picks the next-best release.
+# false: (default) delete + re-search only — the indexer may hand back the very
+#        same broken release and nothing changes.
+#
+# Notes:
+#  - Blocklisting matches an exact release (title/indexer/download id), NOT the
+#    content. A different upload of the same bad encode can still come back.
+#    For a consistently bad release group, add a negative-scored Custom Format.
+#  - Entries are permanent until removed by hand in Activity > Blocklist.
+#  - If "Redownload" under Settings > Download Clients > Failed Download Handling
+#    is enabled, the arr fires its own search on top of Remediarr's. Harmless.
+BLOCKLIST_ON_REPLACE=false
+
 # ====== BAZARR INTEGRATION (OPTIONAL) ======
 # Subtitle management integration with Bazarr
 # Leave empty to disable Bazarr integration (default behavior)

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Remediarr is configured entirely through environment variables. See the [complet
 | `BAZARR_API_KEY` | Bazarr API key | `jkl012...` |
 | `ISSUE_TYPE_AS_BUCKET` | When `true`, the Jellyseerr/Seerr issue **Type** (Audio/Video/Subtitle/Other) drives the action and the **comment is ignored** — users can report an issue by type alone with no keywords required. Audio/Video/Subtitle → delete + re-search; Other → search only. The `*_KEYWORDS` lists are unused while this is on. Default `false`. | `false` |
 | `CONFIRM_REPLACEMENT_IMPORT` | When `true`, Remediarr holds an issue open after triggering a re-download and only comments + closes once the replacement is confirmed imported. TV issues wait for Sonarr's On Import webhook; movie issues wait for Radarr's. If the download never lands, the issue stays open as a signal for manual follow-up. Requires the webhook setup below for each arr you want to confirm. Default `false`. | `false` |
+| `BLOCKLIST_ON_REPLACE` | When `true`, Remediarr marks the grab that produced the bad file as **failed** in Radarr/Sonarr before deleting it, which adds that release to the arr's **Blocklist**. The re-search then skips it instead of potentially grabbing the same broken release again. Blocklisting matches an exact release, not the content — a different upload of the same bad encode can still return. Entries stay until removed in *Activity → Blocklist*. Default `false`. | `false` |
 
 #### Setting up the Sonarr webhook (required for `CONFIRM_REPLACEMENT_IMPORT=true`)
 

--- a/app/config.py
+++ b/app/config.py
@@ -101,6 +101,11 @@ class Settings(BaseSettings):
     # (search-only) and Bazarr-handled subtitle fixes still close at action time,
     # since neither produces a Sonarr import to wait for.
     CONFIRM_REPLACEMENT_IMPORT: bool = False
+    # When true, before deleting a file Remediarr marks the grab that produced it as
+    # failed in Radarr/Sonarr, which blocklists that release. Without this, a
+    # re-search can grab the exact same broken release again and nothing changes.
+    # OFF by default — the existing behavior is unchanged.
+    BLOCKLIST_ON_REPLACE: bool = False
 
     # ===== Keyword buckets (comma-separated) =====
     TV_AUDIO_KEYWORDS: str = "no audio,no sound,missing audio,audio issue,wrong language,not in english"

--- a/app/services/arr_history.py
+++ b/app/services/arr_history.py
@@ -1,0 +1,87 @@
+"""Shared history/blocklist helpers for the Radarr and Sonarr history APIs,
+which are identical in shape. Each arr service module supplies its own
+httpx client, API base, and headers; these functions hold the shared,
+arr-agnostic logic so a fix to one doesn't have to be re-applied by hand to
+the other (that's already happened once in this repo)."""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+import logging
+
+import httpx
+
+log = logging.getLogger("remediarr")
+
+_EPOCH = datetime.min.replace(tzinfo=timezone.utc)
+
+
+def to_dt(s: str) -> Optional[datetime]:
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except Exception:
+        return None
+
+
+def parse_history_listish(data: Any) -> List[Dict[str, Any]]:
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict) and isinstance(data.get("records"), list):
+        return data["records"]
+    return []
+
+
+def newest_first(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return sorted(events, key=lambda e: to_dt(e.get("date") or "") or _EPOCH, reverse=True)
+
+
+def download_id(ev: Dict[str, Any]) -> str:
+    return str(ev.get("downloadId") or (ev.get("data") or {}).get("downloadId") or "")
+
+
+async def fetch_history(
+    client: httpx.AsyncClient, api_base: str, headers: dict,
+    urls: List[str], id_field: str, id_value: int, arr_name: str,
+) -> List[Dict[str, Any]]:
+    """Try each URL in turn; drop records for other series/movies (older
+    *arr builds ignore the id filter on the generic /history endpoint and
+    return global history — without this a foreign release could get
+    blocklisted)."""
+    for url in urls:
+        try:
+            r = await client.get(url, headers=headers)
+        except Exception as e:
+            log.info("%s history request error: %s", arr_name, e)
+            continue
+        if r.status_code >= 400:
+            log.info("%s GET %s failed: %s", arr_name, url.replace(api_base, ""), r.status_code)
+            continue
+        items = [
+            ev for ev in parse_history_listish(r.json())
+            if ev.get(id_field) in (None, id_value)
+        ]
+        if items:
+            return newest_first(items)
+    return []
+
+
+async def mark_history_failed(
+    client: httpx.AsyncClient, api_base: str, headers: dict, history_id: int, arr_name: str,
+) -> bool:
+    """The 'Mark as Failed' action — blocklists the release behind that
+    history record. Note: this is the same endpoint the *arr UI's button
+    uses, and *arr may itself trigger its own replacement search as a side
+    effect of this call, independent of whatever search Remediarr triggers
+    afterward. We don't try to suppress that (no clean API for it) — the
+    blocklist happening first means both searches draw from the same
+    reduced candidate pool, so at worst it's a redundant grab, not a repeat
+    of the original bad release."""
+    for url in (f"{api_base}/history/failed/{history_id}", f"{api_base}/history/failed?id={history_id}"):
+        try:
+            r = await client.post(url, headers=headers, json={})
+        except Exception as e:
+            log.info("%s mark-failed request error: %s", arr_name, e)
+            continue
+        if r.status_code in (200, 201, 202, 204):
+            return True
+        log.info("%s POST %s failed: %s", arr_name, url.replace(api_base, ""), r.status_code)
+    return False

--- a/app/services/radarr.py
+++ b/app/services/radarr.py
@@ -1,6 +1,6 @@
 import os
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 import httpx
 
 from app.services import arr_history as H

--- a/app/services/radarr.py
+++ b/app/services/radarr.py
@@ -3,6 +3,8 @@ import logging
 from typing import Any, Dict, Optional
 import httpx
 
+from app.services import arr_history as H
+
 log = logging.getLogger("remediarr")
 
 BASE = os.getenv("RADARR_URL", "").rstrip("/")
@@ -45,3 +47,61 @@ async def trigger_search_movie(movie_id: int) -> None:
     r = await _client_lazy().post(f"{API}/command", headers=HEADERS, json=body)
     r.raise_for_status()
 
+async def _history_for_movie(movie_id: int) -> List[Dict[str, Any]]:
+    return await H.fetch_history(
+        _client_lazy(), API, HEADERS,
+        urls=[
+            f"{API}/history/movie?movieId={movie_id}",
+            f"{API}/history?movieId={movie_id}&page=1&pageSize=100&sortDirection=descending",
+        ],
+        id_field="movieId", id_value=movie_id, arr_name="Radarr",
+    )
+
+
+async def blocklist_current_release(movie_id: int) -> int:
+    """
+    Blocklist the release that produced the movie file currently on disk, so a
+    re-search cannot grab the exact same (broken) release again.
+
+    Radarr has no "add to blocklist" endpoint; the supported path is marking the
+    'grabbed' history record as failed (what the UI's "Mark as Failed" button does),
+    which blocklists that release. Returns how many releases were blocklisted.
+    """
+    events = await _history_for_movie(movie_id)
+    if not events:
+        log.info("Movie %s: no history to blocklist", movie_id)
+        return 0
+
+    # Find the single newest event (import or grab) for this movie — whichever
+    # produced the file currently on disk. An import event is always newer than
+    # its own grab, so this naturally prefers the import when one exists. If
+    # THAT event has no downloadId (e.g. a manual import), we deliberately give
+    # up rather than fall through to an OLDER event's downloadId, which could
+    # belong to an already-superseded release.
+    target_dl = ""
+    for ev in events:  # newest first
+        etype = (ev.get("eventType") or "").lower()
+        if etype in ("downloadfolderimported", "grabbed"):
+            target_dl = H.download_id(ev)
+            break
+
+    if not target_dl:
+        log.info("Movie %s: newest history event has no downloadId to blocklist", movie_id)
+        return 0
+
+    target_hid: Optional[int] = None
+    for ev in events:
+        if (ev.get("eventType") or "").lower() != "grabbed":
+            continue
+        hid = ev.get("id")
+        if isinstance(hid, int) and H.download_id(ev) == target_dl:
+            target_hid = hid
+            break
+
+    if target_hid is None:
+        log.info("Movie %s: no grabbed history record for downloadId %s", movie_id, target_dl)
+        return 0
+
+    blocked = 1 if await H.mark_history_failed(_client_lazy(), API, HEADERS, target_hid, "Radarr") else 0
+    log.info("Movie %s blocklist_current_release: blocked=%s", movie_id, blocked)
+    return blocked

--- a/app/services/sonarr.py
+++ b/app/services/sonarr.py
@@ -3,6 +3,8 @@ import logging
 from typing import Any, Dict, List, Optional, Tuple
 import httpx
 
+from app.services import arr_history as H
+
 log = logging.getLogger("remediarr")
 
 BASE = os.getenv("SONARR_URL", "").rstrip("/")
@@ -92,3 +94,97 @@ async def get_seasons_with_files(series_id: int) -> set[int]:
         if isinstance(sn, int) and sn > 0 and e.get("hasFile"):
             seasons.add(sn)
     return seasons
+
+
+def _episode_id(ev: Dict[str, Any]) -> Optional[int]:
+    eid = ev.get("episodeId")
+    if not isinstance(eid, int):
+        eid = (ev.get("data") or {}).get("episodeId")
+    try:
+        return int(eid)
+    except (TypeError, ValueError):
+        return None
+
+
+async def _history_for_series(series_id: int) -> List[Dict[str, Any]]:
+    return await H.fetch_history(
+        _client_lazy(), API, HEADERS,
+        urls=[
+            f"{API}/history/series?seriesId={series_id}",
+            f"{API}/history?seriesId={series_id}&page=1&pageSize=200&sortDirection=descending",
+        ],
+        id_field="seriesId", id_value=series_id, arr_name="Sonarr",
+    )
+
+
+async def blocklist_current_releases(series_id: int, episode_ids: List[int]) -> int:
+    """
+    Blocklist the release(s) that produced the episode files currently on disk, so a
+    re-search cannot grab the exact same (broken) release again.
+
+    Sonarr has no "add to blocklist" endpoint; the supported path is marking the
+    'grabbed' history record as failed (what the UI's "Mark as Failed" button does),
+    which blocklists that release. A season pack yields one grab shared by many
+    episodes, so downloadIds are de-duplicated. Returns how many were blocklisted.
+    """
+    if not episode_ids:
+        return 0
+    events = await _history_for_series(series_id)
+    if not events:
+        log.info("Series %s: no history to blocklist", series_id)
+        return 0
+
+    wanted = set(episode_ids)
+
+    # Resolve each wanted episode INDEPENDENTLY to the downloadId of the release
+    # currently on disk for it: the newest event (import or grab) for that
+    # episode. An import is always newer than its own grab, so it naturally wins
+    # when present; if the episode hasn't been imported yet (or was imported with
+    # no downloadId, e.g. manually), the newest grab is the correct fallback.
+    # Doing this per-episode — instead of one shared decision for the whole
+    # batch — means one episode having (or lacking) an import record can't affect
+    # any other episode's result. An episode whose newest event has no downloadId
+    # is skipped rather than risking an older, superseded release's id.
+    target_dls: set[str] = set()
+    seen_eps: set[int] = set()
+    for ev in events:  # newest first
+        eid = _episode_id(ev)
+        if eid is None or eid not in wanted or eid in seen_eps:
+            continue
+        etype = (ev.get("eventType") or "").lower()
+        if etype not in ("downloadfolderimported", "grabbed"):
+            continue
+        seen_eps.add(eid)
+        did = H.download_id(ev)
+        if did:
+            target_dls.add(did)
+
+    if not target_dls:
+        log.info("Series %s: no matching history with a downloadId for episodes %s", series_id, sorted(wanted))
+        return 0
+
+    # One 'grabbed' record per distinct downloadId (season packs share one
+    # downloadId across many episodes — de-duplicated so it's only marked failed,
+    # and only fires one re-download, once per release).
+    targets: List[int] = []
+    seen_dls: set[str] = set()
+    for ev in events:
+        if (ev.get("eventType") or "").lower() != "grabbed":
+            continue
+        hid = ev.get("id")
+        if not isinstance(hid, int):
+            continue
+        did = H.download_id(ev)
+        if did not in target_dls or did in seen_dls:
+            continue
+        seen_dls.add(did)
+        targets.append(hid)
+        if len(seen_dls) == len(target_dls):
+            break
+
+    blocked = 0
+    for hid in targets:
+        if await H.mark_history_failed(_client_lazy(), API, HEADERS, hid, "Sonarr"):
+            blocked += 1
+    log.info("Series %s blocklist_current_releases: episodes=%s blocked=%s", series_id, episode_ids, blocked)
+    return blocked

--- a/app/webhooks/handlers.py
+++ b/app/webhooks/handlers.py
@@ -652,8 +652,16 @@ async def _handle_tv_specific_episodes(issue_id: int, series: Dict[str, Any], se
         # would double-blocklist it and fire a second redownload.
         await _blocklist_episodes(series_id, all_episode_ids)
         for ep_num, ep_ids in handled_eps:
-            removed = await S.delete_episodefiles(series_id, ep_ids)
-            log.info("Deleted %s files for S%02dE%02d", removed, season, ep_num)
+            # One episode's delete failing (e.g. a Sonarr timeout) shouldn't abort
+            # the whole batch — every other episode here was just blocklisted above,
+            # so skipping the rest of the loop on an exception would leave them
+            # blocklisted but never actually deleted/re-searched, which is worse
+            # than not blocklisting at all.
+            try:
+                removed = await S.delete_episodefiles(series_id, ep_ids)
+                log.info("Deleted %s files for S%02dE%02d", removed, season, ep_num)
+            except Exception as e:
+                log.warning("Failed to delete files for S%02dE%02d: %s", season, ep_num, e)
 
     await S.trigger_episode_search(all_episode_ids)
 

--- a/app/webhooks/handlers.py
+++ b/app/webhooks/handlers.py
@@ -550,6 +550,30 @@ async def _handle_subtitle_with_bazarr(issue_id: int, media_type: str, media_id:
     
     return False
 
+
+async def _blocklist_movie(movie_id: int) -> None:
+    """Blocklist the release behind the current file so the re-search can't grab it again."""
+    if not cfg.BLOCKLIST_ON_REPLACE:
+        return
+    try:
+        blocked = await R.blocklist_current_release(movie_id)
+        log.info("Blocklisted %s release(s) for movie %s", blocked, movie_id)
+    except Exception as e:
+        # Never let a blocklist failure block the delete + re-search.
+        log.warning("Blocklist failed for movie %s: %s", movie_id, e)
+
+
+async def _blocklist_episodes(series_id: int, episode_ids: List[int]) -> None:
+    """Blocklist the release(s) behind the current files so the re-search can't grab them again."""
+    if not cfg.BLOCKLIST_ON_REPLACE or not episode_ids:
+        return
+    try:
+        blocked = await S.blocklist_current_releases(series_id, episode_ids)
+        log.info("Blocklisted %s release(s) for series %s episodes %s", blocked, series_id, episode_ids)
+    except Exception as e:
+        log.warning("Blocklist failed for series %s episodes %s: %s", series_id, episode_ids, e)
+
+
 async def _handle_movie(issue_id: int, movie: Dict[str, Any], bucket: str) -> None:
     movie_id = movie["id"]
     title = movie.get("title") or f"Movie {movie_id}"
@@ -575,6 +599,7 @@ async def _handle_movie(issue_id: int, movie: Dict[str, Any], bucket: str) -> No
     # Delete + re-search unless a remediation for this movie is already in flight.
     if not already_pending:
         if bucket in ("audio", "video", "subtitle", "wrong"):
+            await _blocklist_movie(movie_id)
             log.info("Deleting movie files for movie %s", movie_id)
             removed = await R.delete_moviefiles(movie_id)
             log.info("Deleted %s movie files", removed)
@@ -607,26 +632,32 @@ async def _handle_tv_specific_episodes(issue_id: int, series: Dict[str, Any], se
     title = series.get("title") or f"Series {series_id}"
 
     all_episode_ids: List[int] = []
-    handled_eps: List[int] = []
+    handled_eps: List[Tuple[int, List[int]]] = []
 
     for ep_num in episodes:
         ep_ids = await S.episode_ids_for(series_id, season, ep_num)
         if not ep_ids:
             log.info("No episode file in Sonarr for S%02dE%02d, skipping", season, ep_num)
             continue
-        if bucket in ("audio", "video", "subtitle"):
-            removed = await S.delete_episodefiles(series_id, ep_ids)
-            log.info("Deleted %s files for S%02dE%02d", removed, season, ep_num)
         all_episode_ids.extend(ep_ids)
-        handled_eps.append(ep_num)
+        handled_eps.append((ep_num, ep_ids))
 
     if not handled_eps:
         log.info("No matching episode files found in Sonarr for S%02d eps %s", season, episodes)
         return
 
+    if bucket in ("audio", "video", "subtitle"):
+        # Blocklist all reported episodes in ONE pass before deleting: episodes from
+        # the same season pack share a downloadId, and marking that grab failed twice
+        # would double-blocklist it and fire a second redownload.
+        await _blocklist_episodes(series_id, all_episode_ids)
+        for ep_num, ep_ids in handled_eps:
+            removed = await S.delete_episodefiles(series_id, ep_ids)
+            log.info("Deleted %s files for S%02dE%02d", removed, season, ep_num)
+
     await S.trigger_episode_search(all_episode_ids)
 
-    ep_list = ", ".join(f"E{e:02d}" for e in handled_eps)
+    ep_list = ", ".join(f"E{e:02d}" for e, _ in handled_eps)
     msg = f"{title} S{season:02d} ({ep_list}): replaced files; new downloads grabbed. Closing this issue. If anything's still off, comment and I'll take another pass."
     if COMMENT_ON_ACTION:
         await jelly_comment(issue_id, f"{PREFIX} {msg}")
@@ -652,6 +683,7 @@ async def _handle_tv_season(issue_id: int, series: Dict[str, Any], season: int, 
         log.info("Falling back to traditional subtitle handling for series %s season %s", series_id, season)
 
     if bucket in ("audio", "video", "subtitle"):
+        await _blocklist_episodes(series_id, await S.get_all_episode_ids_for_season(series_id, season))
         removed = await S.delete_all_episodefiles_for_season(series_id, season)
         log.info("Deleted %s episode files for series %s season %s", removed, series_id, season)
 
@@ -702,6 +734,7 @@ async def _handle_tv(issue_id: int, series: Dict[str, Any], season: int, episode
     if not already_pending:
         removed = 0
         if bucket in ("audio", "video", "subtitle"):
+            await _blocklist_episodes(series_id, episode_ids)
             log.info("Deleting episode files for series %s, episodes %s", series_id, episode_ids)
             removed = await S.delete_episodefiles(series_id, episode_ids)
             log.info("Deleted %s episode files", removed)

--- a/tests/test_blocklist_on_replace.py
+++ b/tests/test_blocklist_on_replace.py
@@ -1,0 +1,165 @@
+"""Tests for BLOCKLIST_ON_REPLACE: sonarr.blocklist_current_releases and
+radarr.blocklist_current_release. These call real Sonarr/Radarr history +
+mark-as-failed endpoints in production; here _history_for_* and
+mark_history_failed are monkeypatched so the tests exercise only the
+target-selection logic (the part that was actually buggy)."""
+
+import asyncio
+
+import pytest
+
+from app.services import sonarr as S
+from app.services import radarr as R
+from app.services import arr_history as H
+
+
+def _grabbed(hid, episode_id, download_id, date):
+    return {"id": hid, "eventType": "grabbed", "episodeId": episode_id,
+             "downloadId": download_id, "date": date}
+
+
+def _imported(episode_id, download_id, date):
+    return {"eventType": "downloadFolderImported", "episodeId": episode_id,
+             "downloadId": download_id, "date": date}
+
+
+def _grabbed_movie(hid, download_id, date):
+    return {"id": hid, "eventType": "grabbed", "downloadId": download_id, "date": date}
+
+
+def _imported_movie(download_id, date):
+    return {"eventType": "downloadFolderImported", "downloadId": download_id, "date": date}
+
+
+@pytest.fixture
+def blocked(monkeypatch):
+    """Records (arr_name, history_id) for every mark_history_failed call and
+    always reports success, without making a real HTTP call."""
+    calls = []
+
+    async def fake_mark(client, api_base, headers, history_id, arr_name):
+        calls.append((arr_name, history_id))
+        return True
+
+    monkeypatch.setattr(H, "mark_history_failed", fake_mark)
+    return calls
+
+
+def test_sonarr_multi_episode_no_import_history_blocklists_both(monkeypatch, blocked):
+    # Bug: previously the "no import event" fallback took only the FIRST
+    # matching grab across the whole batch, then broke out of the loop
+    # entirely — leaving other episodes' releases un-blocklisted.
+    events = [
+        _grabbed(101, episode_id=1, download_id="dl-a", date="2026-01-02T00:00:00Z"),
+        _grabbed(102, episode_id=2, download_id="dl-b", date="2026-01-01T00:00:00Z"),
+    ]
+
+    async def fake_history(series_id):
+        return events
+
+    monkeypatch.setattr(S, "_history_for_series", fake_history)
+
+    blocked_count = asyncio.run(S.blocklist_current_releases(series_id=1, episode_ids=[1, 2]))
+    assert blocked_count == 2
+    assert set(blocked) == {("Sonarr", 101), ("Sonarr", 102)}
+
+
+def test_sonarr_partial_import_coverage_still_blocklists_both(monkeypatch, blocked):
+    # Bug: one episode having an import record made `imported_dls` non-empty,
+    # which switched the matching mode for the WHOLE batch and silently
+    # dropped the episode that had no import record of its own.
+    events = [
+        _imported(episode_id=1, download_id="dl-a", date="2026-01-02T00:00:00Z"),
+        _grabbed(201, episode_id=1, download_id="dl-a", date="2026-01-01T00:00:00Z"),
+        # Episode 2 has no import event at all — only ever grabbed.
+        _grabbed(202, episode_id=2, download_id="dl-b", date="2026-01-01T00:00:00Z"),
+    ]
+
+    async def fake_history(series_id):
+        return events
+
+    monkeypatch.setattr(S, "_history_for_series", fake_history)
+
+    blocked_count = asyncio.run(S.blocklist_current_releases(series_id=1, episode_ids=[1, 2]))
+    assert blocked_count == 2
+    assert set(blocked) == {("Sonarr", 201), ("Sonarr", 202)}
+
+
+def test_sonarr_season_pack_shared_download_id_blocklisted_once(monkeypatch, blocked):
+    events = [
+        _imported(episode_id=1, download_id="dl-pack", date="2026-01-02T00:00:01Z"),
+        _imported(episode_id=2, download_id="dl-pack", date="2026-01-02T00:00:02Z"),
+        _grabbed(301, episode_id=1, download_id="dl-pack", date="2026-01-01T00:00:00Z"),
+    ]
+
+    async def fake_history(series_id):
+        return events
+
+    monkeypatch.setattr(S, "_history_for_series", fake_history)
+
+    blocked_count = asyncio.run(S.blocklist_current_releases(series_id=1, episode_ids=[1, 2]))
+    assert blocked_count == 1
+    assert blocked == [("Sonarr", 301)]
+
+
+def test_sonarr_no_matching_history_blocklists_nothing(monkeypatch, blocked):
+    async def fake_history(series_id):
+        return [_grabbed(401, episode_id=99, download_id="dl-x", date="2026-01-01T00:00:00Z")]
+
+    monkeypatch.setattr(S, "_history_for_series", fake_history)
+
+    blocked_count = asyncio.run(S.blocklist_current_releases(series_id=1, episode_ids=[1]))
+    assert blocked_count == 0
+    assert blocked == []
+
+
+def test_radarr_normal_import_blocklists_it(monkeypatch, blocked):
+    events = [
+        _imported_movie(download_id="dl-a", date="2026-01-02T00:00:00Z"),
+        _grabbed_movie(501, download_id="dl-a", date="2026-01-01T00:00:00Z"),
+    ]
+
+    async def fake_history(movie_id):
+        return events
+
+    monkeypatch.setattr(R, "_history_for_movie", fake_history)
+
+    blocked_count = asyncio.run(R.blocklist_current_release(movie_id=1))
+    assert blocked_count == 1
+    assert blocked == [("Radarr", 501)]
+
+
+def test_radarr_newest_import_missing_download_id_gives_up(monkeypatch, blocked):
+    # Bug: the old code kept walking PAST an import with no downloadId (e.g. a
+    # manual import) to an OLDER import that did have one — blocklisting an
+    # already-superseded release instead of doing nothing. Correct behavior is
+    # to give up rather than risk blocklisting the wrong release.
+    events = [
+        _imported_movie(download_id="", date="2026-01-03T00:00:00Z"),   # newest, no id
+        _imported_movie(download_id="dl-old", date="2026-01-02T00:00:00Z"),  # stale
+        _grabbed_movie(601, download_id="dl-old", date="2026-01-01T00:00:00Z"),
+    ]
+
+    async def fake_history(movie_id):
+        return events
+
+    monkeypatch.setattr(R, "_history_for_movie", fake_history)
+
+    blocked_count = asyncio.run(R.blocklist_current_release(movie_id=1))
+    assert blocked_count == 0
+    assert blocked == []
+
+
+def test_radarr_no_import_falls_back_to_newest_grab(monkeypatch, blocked):
+    events = [
+        _grabbed_movie(701, download_id="dl-a", date="2026-01-01T00:00:00Z"),
+    ]
+
+    async def fake_history(movie_id):
+        return events
+
+    monkeypatch.setattr(R, "_history_for_movie", fake_history)
+
+    blocked_count = asyncio.run(R.blocklist_current_release(movie_id=1))
+    assert blocked_count == 1
+    assert blocked == [("Radarr", 701)]


### PR DESCRIPTION
Adds the blocklist support discussed in #92.

Today a delete + re-search can hand back the exact same broken release, so the
user reports the issue again and nothing changes. With `BLOCKLIST_ON_REPLACE=true`,
Remediarr marks the grab that produced the file on disk as **failed** first — the
same API call behind the UI's "Mark as Failed" — which blocklists that release, so
the search that follows picks the next-best one.

**Off by default.** With the flag unset, behaviour is byte-for-byte unchanged.

### How the right grab is found

Neither arr has an "add to blocklist" endpoint, so this walks history newest-first:

- Match the `downloadId` of the **most recent import** per episode/movie, then mark
  only the `grabbed` record carrying that id. Superseded releases from an earlier
  upgrade are still in history but no longer on disk, so they are never touched.
- Season packs share one `downloadId` across many episodes, so ids are de-duplicated
  and the grab is marked failed **once** (marking twice would fire a second redownload).
- Older arrs ignore `movieId`/`seriesId` on the generic `/history` endpoint and return
  global history, so foreign records are filtered out — it can never blocklist an
  unrelated item.
- No import event to match on → fall back to the most recent grab only.
- A blocklist failure is logged and swallowed; it never blocks the delete + re-search.

Wired into all five replace paths: movie, single episode, specific episodes, season,
and the confirm-import path.

### Note for the reviewer

`_handle_tv_specific_episodes` and `_handle_tv_season` are each **defined twice** in
`handlers.py` (byte-identical; Python keeps the second). I patched both copies rather
than deleting the dead ones, to keep this PR to a single concern — happy to send a
separate cleanup PR if you want them removed.

`_handle_tv_specific_episodes` collects episode ids first and deletes in a second
loop, so the whole set can be blocklisted in one pass before any deletion.