### PR TITLE
fix: restore missing get_all_episode_ids_for_season (crashes season-wide blocklist)

### DIFF
--- a/app/services/sonarr.py
+++ b/app/services/sonarr.py
@@ -40,6 +40,10 @@ async def episode_ids_for(series_id: int, season: int, episode: int) -> List[int
                 ids.append(e["id"])
     return ids
 
+async def get_all_episode_ids_for_season(series_id: int, season: int) -> List[int]:
+    eps = await list_episodes(series_id)
+    return [e["id"] for e in eps if e.get("seasonNumber") == season and isinstance(e.get("id"), int)]
+
 async def delete_episodefiles(series_id: int, episode_ids: List[int]) -> int:
     eps = await list_episodes(series_id)
     file_ids: List[int] = []

--- a/tests/test_blocklist_on_replace.py
+++ b/tests/test_blocklist_on_replace.py
@@ -163,3 +163,33 @@ def test_radarr_no_import_falls_back_to_newest_grab(monkeypatch, blocked):
     blocked_count = asyncio.run(R.blocklist_current_release(movie_id=1))
     assert blocked_count == 1
     assert blocked == [("Radarr", 701)]
+
+
+def test_season_wide_blocklist_calls_get_all_episode_ids_for_season(monkeypatch, blocked):
+    # Regression test: _handle_tv_season's blocklist step calls
+    # S.get_all_episode_ids_for_season, which was deleted as dead code in an
+    # earlier cleanup pass and then silently reintroduced as a real call
+    # site by the blocklist feature during a later rebase — the function
+    # itself never came back, so this raised AttributeError in production
+    # any time a season-wide remediation ran with BLOCKLIST_ON_REPLACE=true.
+    assert hasattr(S, "get_all_episode_ids_for_season")
+
+    async def fake_list_episodes(series_id):
+        return [
+            {"id": 1, "seasonNumber": 2, "episodeNumber": 1},
+            {"id": 2, "seasonNumber": 2, "episodeNumber": 2},
+            {"id": 3, "seasonNumber": 3, "episodeNumber": 1},
+        ]
+
+    async def fake_history(series_id):
+        return []
+
+    monkeypatch.setattr(S, "list_episodes", fake_list_episodes)
+    monkeypatch.setattr(S, "_history_for_series", fake_history)
+
+    # Exercises the exact call handlers.py makes: get the season's episode
+    # ids, then blocklist them. Must not raise, and must only include season 2.
+    episode_ids = asyncio.run(S.get_all_episode_ids_for_season(series_id=42, season=2))
+    blocked_count = asyncio.run(S.blocklist_current_releases(series_id=42, episode_ids=episode_ids))
+    assert episode_ids == [1, 2]
+    assert blocked_count == 0


### PR DESCRIPTION
## Summary
`_handle_tv_season`'s blocklist step (added in #100, `BLOCKLIST_ON_REPLACE`) calls `S.get_all_episode_ids_for_season` — but that function was deleted as dead code in #97's vulture cleanup (correct at the time: it had no callers). #100's rebase reintroduced a real call site without the function coming back with it.

**Live on `main` right now**: any season-wide TV remediation (a `problemEpisode=0`/"All Episodes" report for a specific season) with `BLOCKLIST_ON_REPLACE=true` raises `AttributeError` instead of remediating.

## Fix
Restored `get_all_episode_ids_for_season` exactly as it was before #97 deleted it. Added a regression test that exercises the actual call `handlers.py` makes (get the season's episode ids, then blocklist them) so this can't silently reappear.

Found while verifying an unrelated refactor end-to-end rather than trusting unit tests alone — the existing suite never exercised this exact path, which is why it shipped through both #97 and #100's review.

## Test plan
- [x] `pytest` — all passing, including the new regression test
- [x] `ruff`/`vulture` — no new findings (only the pre-existing, already-deferred `Tuple` import unrelated to this)
- [x] Manually ran `_handle_tv_season` end-to-end with `BLOCKLIST_ON_REPLACE=true` and mocked I/O — confirmed it crashed before this fix and completes cleanly after